### PR TITLE
_mssql.pyx: Prevent error string growing

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -313,10 +313,12 @@ cdef void clr_err(MSSQLConnection conn):
         conn.last_msg_no = 0
         conn.last_msg_severity = 0
         conn.last_msg_state = 0
+        conn.last_msg_str[0] = 0
     else:
         _mssql_last_msg_no = 0
         _mssql_last_msg_severity = 0
         _mssql_last_msg_state = 0
+        _mssql_last_msg_str[0] = 0
 
 cdef RETCODE db_cancel(MSSQLConnection conn):
     cdef RETCODE rtc
@@ -1445,7 +1447,7 @@ cdef int maybe_raise_MSSQLDatabaseException(MSSQLConnection conn) except 1:
 
     error_msg = get_last_msg_str(conn)
     if len(error_msg) == 0:
-        error_msg = "Unknown error"
+        error_msg = b"Unknown error"
 
     ex = MSSQLDatabaseException((get_last_msg_no(conn), error_msg))
     (<MSSQLDatabaseException>ex).text = error_msg


### PR DESCRIPTION
with repeated failed connection attempts.

Fixes GH-145

Cc: @sontek

``` bash
(py26.venv)marca@marca-mac2:~/dev/git-repos/pymssql$ python stuff/test_pymssql_connect_failure.py
Exception str:
     DB-Lib error message 20017, severity 9:
    Unexpected EOF from the server
     DB-Lib error message 20002, severity 9:
    Adaptive Server connection failed

Exception str:
     DB-Lib error message 20017, severity 9:
    Unexpected EOF from the server
     DB-Lib error message 20002, severity 9:
    Adaptive Server connection failed

Exception str:
     DB-Lib error message 20017, severity 9:
    Unexpected EOF from the server
     DB-Lib error message 20002, severity 9:
    Adaptive Server connection failed

Exception str:
     DB-Lib error message 20017, severity 9:
    Unexpected EOF from the server
     DB-Lib error message 20002, severity 9:
    Adaptive Server connection failed

Exception str:
     DB-Lib error message 20017, severity 9:
    Unexpected EOF from the server
     DB-Lib error message 20002, severity 9:
    Adaptive Server connection failed
```
