### PR TITLE
_mssql.pyx: Zero init global last_msg_* vars

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -65,8 +65,11 @@ cdef int _mssql_last_msg_severity = 0
 cdef int _mssql_last_msg_state = 0
 cdef int _mssql_last_msg_line = 0
 cdef char *_mssql_last_msg_str = <char *>PyMem_Malloc(PYMSSQL_MSGSIZE)
+_mssql_last_msg_str[0] = <char>0
 cdef char *_mssql_last_msg_srv = <char *>PyMem_Malloc(PYMSSQL_MSGSIZE)
+_mssql_last_msg_srv[0] = <char>0
 cdef char *_mssql_last_msg_proc = <char *>PyMem_Malloc(PYMSSQL_MSGSIZE)
+_mssql_last_msg_proc[0] = <char>0
 IF PYMSSQL_DEBUG == 1:
     cdef int _row_count = 0
 


### PR DESCRIPTION
Otherwise they can have random garbage in them. I discovered this while testing PR #151 on Ubuntu 13, because that change causes a connection failure to no longer clobber `_mssql_last_msg_str`, so that you can then see the random garbage in it.

``` cython
 cdef char *_mssql_last_msg_str = <char *>PyMem_Malloc(PYMSSQL_MSGSIZE)
+_mssql_last_msg_str[0] = <char>0
 cdef char *_mssql_last_msg_srv = <char *>PyMem_Malloc(PYMSSQL_MSGSIZE)
+_mssql_last_msg_srv[0] = <char>0
 cdef char *_mssql_last_msg_proc = <char *>PyMem_Malloc(PYMSSQL_MSGSIZE)
+_mssql_last_msg_proc[0] = <char>0
```
