### PR TITLE
Use "(No column name)" as column name when as_dict and no column name

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -1012,7 +1012,7 @@ cdef class MSSQLConnection:
             # and reduces confusion from users who use as_dict=True and then do
             # "SELECT MAX(x) FROM..." and get rows with no columns.
             if not name:
-                name = '(No column name)'
+                name = '(No column name #%d)' % col
 
             row_dict[name] = value
             row_dict[col - 1] = value

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -290,7 +290,16 @@ class CursorBase(DBAPIBase):
     def test_as_dict_no_column_name(self):
         cur = self.conn.cursor(as_dict=True)
         cur.execute("SELECT MAX(x) FROM (VALUES (1), (2), (3)) AS foo(x)")
-        eq_(cur.fetchall(), [{'(No column name)': 3}])
+        eq_(cur.fetchall(), [{'(No column name #1)': 3}])
+
+    def test_as_dict_no_column_name_2(self):
+        cur = self.conn.cursor(as_dict=True)
+        cur.execute(
+            "SELECT MAX(x), MAX(y) "
+            "FROM (VALUES (1, 2), (2, 3), (3, 4)) AS foo(x, y)")
+        eq_(cur.fetchall(), [{
+            '(No column name #1)': 3,
+            '(No column name #2)': 4}])
 
     def test_fetchmany(self):
         cur = self.conn.cursor()


### PR DESCRIPTION
I propose that we modify pymssql to use a column name of `"(No column name)"` when the user uses `as_dict=True` and then does a query which returns output columns that are not named -- e.g.:

``` sql
SELECT MAX(x) FROM (VALUES (1), (2), (3)) AS foo(x)
```

``` python
cursor = conn.cursor(as_dict=True)
cursor.execute("SELECT MAX(x) FROM (VALUES (1), (2), (3)) AS foo(x)")
print(cursor.fetchall())
# Outputs:
# [{}]
# Whoa, what happened to MAX(x)?!?!
```

Currently, we don't add the column to the result row if it has no name. This confuses people. See [this mailing list thread](https://groups.google.com/forum/?fromgroups#!topic/pymssql/JoZpmNZFtxM) for an example.

I have a more detailed example at: https://gist.github.com/msabramo/8319097

I chose `"(No column name)"` because this is what SQL Server Management Studio uses.

So the output of the above Python snippet with this change is:

```
[{'(No column name)': 3}]
```
