### PR TITLE
MSSQLConnection: Add `with` (context manager) support

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -569,6 +569,12 @@ cdef class MSSQLConnection:
         log("_mssql.MSSQLConnection.__dealloc__()")
         self.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     def __iter__(self):
         assert_connected(self)
         clr_err(self)

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -8,7 +8,7 @@ except ImportError:
     import unittest
 
 from pymssql import InterfaceError
-from .helpers import pymssqlconn
+from .helpers import pymssqlconn, mssqlconn
 
 
 class TestContextManagers(unittest.TestCase):
@@ -35,3 +35,10 @@ class TestContextManagers(unittest.TestCase):
             cursor.execute("SELECT @@version AS version")
 
         self.assertEqual(str(context.exception), "Cursor is closed.")
+
+    def test_mssql_Connection_with(self):
+        with mssqlconn() as conn:
+            conn.execute_query("SELECT @@version AS version")
+            self.assertTrue(conn.connected)
+
+        self.assertFalse(conn.connected)


### PR DESCRIPTION
Add context manager support to `MSSQLConnection` for using `with` statement ([PEP 343](http://www.python.org/dev/peps/pep-0343/)).

Continues context manager work done for `pymssql.Connection` and `pymssql.Cursor` in https://github.com/pymssql/pymssql/commit/b9ef4ba2

This will be handy to have in tests to get rid of explicit `close` calls.

e.g.:

``` python
        conn = mssqlconn()
        conn.execute_query("SELECT @@version AS version")
        conn.close()
```

can become:

``` python
        with mssqlconn() as conn:
            conn.execute_query("SELECT @@version AS version")
```

Cc: @rsyring, @damoxc, @ramiro 
