### PR TITLE
Add section to docs describing issue where old pymssql versions return no rows when used with new FreeTDS versions

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -227,7 +227,7 @@ The solution is to supply a name for all columns -- e.g.::
     [{u'MAX(x)': 3}]
 
 This behavior was changed in https://github.com/pymssql/pymssql/pull/160 --
-with this change, if you specify `as_dict=True` and omit column names, an
+with this change, if you specify ``as_dict=True`` and omit column names, an
 exception will be raised::
 
     >>> cursor.execute("SELECT MAX(x) FROM (VALUES (1), (2), (3)) AS foo(x)")


### PR DESCRIPTION
This one has come up several times at SurveyMonkey and people sometimes get confused even about which versions have the problems (people often think the new pymssql can't work with an old FreeTDS, which is not true; it's only the old version of pymssql that can't work with the new FreeTDS :-))

Basically, I'm describing this issue: https://github.com/pymssql/pymssql/issues/137
