### PR TITLE
setup.py: Remove unreachable code from clean command.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -284,10 +284,6 @@ class clean(_clean):
         for ext in self.distribution.ext_modules:
             cy_sources = [s for s in ext.sources if s.endswith('.pyx')]
             for cy_source in cy_sources:
-                c_source = cy_source[:-3] + 'c'
-                if osp.exists(c_source):
-                    log.info('removing %s', c_source)
-                    os.remove(c_source)
                 so_built = cy_source[:-3] + 'so'
                 if osp.exists(so_built):
                     log.info('removing %s', so_built)


### PR DESCRIPTION
If Cython-generated .c files are present then the logic involving
the have_c_files global var won't allow the code in charge of
removal of these same files to run.
