### PR TITLE
Activate pymssql.get_freetds_version() function.

### DIFF
--- a/cpp_helpers.h
+++ b/cpp_helpers.h
@@ -38,3 +38,10 @@
 #else
 #define FREETDS_SUPPORTS_DBSETLDBNAME 0
 #endif
+
+#ifdef CT_CONFIG
+#define FREETDS_HAS_CT_CONFIG 1
+#else
+#define FREETDS_HAS_CT_CONFIG 0
+#endif
+#define FREETDS_HAS_CT_CONFIG 1

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ else:
     else:
         print('setup.py: Not using bundled FreeTDS')
 
-    libraries = ['sybdb']
+    libraries = ['sybdb', 'ct']
 
     with stdchannel_redirected(sys.stderr, os.devnull):
         if compiler.has_function('clock_gettime', libraries=['rt']):
@@ -251,6 +251,7 @@ class build_ext(_build_ext):
                 libraries = [
                     'libiconv', 'iconv',
                     'sybdb',
+                    'ct',
                     'ws2_32', 'wsock32', 'kernel32',
                 ]
             else:


### PR DESCRIPTION
With FreeTDS versions that support it (>= 0.91), it returns information
provided by the ct_config() API.

With older versions of FreeTDS it raises NotSupportedError.

This commmit also add linking to libct when building pymssql and _mssql.
