### PR TITLE
Make sure tds_version property of _mssql layer connections always has a ...

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -502,10 +502,14 @@ cdef class MSSQLConnection:
         """
         def __get__(self):
             cdef int version = dbtds(self.dbproc)
-            if version == 9:
+            if version == 10:
+                return 9.0
+            elif version == 9:
                 return 8.0
             elif version == 8:
                 return 7.0
+            elif version == 6:
+                return 5.0
             elif version == 4:
                 return 4.2
 

--- a/docs/ref/_mssql.rst
+++ b/docs/ref/_mssql.rst
@@ -132,8 +132,8 @@ Functions
 
 .. attribute:: MSSQLConnection.tds_version
 
-   The TDS version used by this connection. Can be one of ``'4.2'``, ``'7.0'``
-   and ``'8.0'``.
+   The TDS version used by this connection. Can be one of ``4.2``, ``5.0``
+   ``7.0``, ``8.0`` and ``9.0``.
 
 ``MSSQLConnection`` object methods
 ----------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,6 +83,14 @@ class TestConfig(object):
         assert b'major_version = 7' in config_dump
         assert b'minor_version = 1' in config_dump
 
+    def test_tds_protocol_version_72(self):
+        config_dump = self.connect(
+            server='dontnameyourserverthis',
+            tds_version='7.2'
+            )
+        assert b'major_version = 7' in config_dump
+        assert b'minor_version = 2' in config_dump
+
     def test_tds_protocol_version_invalid(self):
         try:
             self.connect(tds_version='1.0')

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -9,7 +9,7 @@ except ImportError:
 
 import _mssql
 
-from .helpers import config, skip_test
+from .helpers import config, skip_test, mssqlconn
 server = config.server
 username = config.user
 password = config.password
@@ -110,3 +110,10 @@ class TestCons(unittest.TestCase):
                     self.assertEqual(exc_message, last_exc_message)
 
                 last_exc_message = exc_message
+
+    def test_valid_tds_version_property(self):
+        # Issue #211 (https://github.com/pymssql/pymssql/issues/211)
+        conn = mssqlconn()
+        self.assertIsNotNone(conn.tds_version)
+        self.assertTrue(conn.tds_version > 0)
+        conn.close()


### PR DESCRIPTION
...valid value.

It was None when client app asked for TDS version 7.2. Fixes #211.
