### PR TITLE
Fix tds_version _mssql connection property value for TDS > 7.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,19 @@ Features
 .. _SQL Server instances: http://www.windowsazure.com/en-us/services/sql-database/
 .. _Azure: https://www.windowsazure.com/
 
+Bug Fixes
+---------
+
+- Fixes in ``td_version``  ``_mssql`` connections property value
+
+  Made it work with TDS protocol version 7.2.
+
+  The value returned for TDS version 7.1 is still 8.0 for backward
+  compatibility (this is because such feature got added in times when
+  Microsoft documentation labeled the two protocol versions that followed 7.0
+  as 8.0 and 9.0; later it changed them to 7.1 and 7.2 respectively) and will
+  be corrected in a future release.
+
 Version 2.1.0 - 2014-02-25 - `Marc Abramowitz <http://marc-abramowitz.com/>`_
 =============================================================================
 

--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -503,9 +503,9 @@ cdef class MSSQLConnection:
         def __get__(self):
             cdef int version = dbtds(self.dbproc)
             if version == 10:
-                return 9.0
+                return 7.2
             elif version == 9:
-                return 8.0
+                return 8.0  # Actually 7.1, return 8.0 to keep backward compatibility
             elif version == 8:
                 return 7.0
             elif version == 6:

--- a/docs/ref/_mssql.rst
+++ b/docs/ref/_mssql.rst
@@ -133,7 +133,7 @@ Functions
 .. attribute:: MSSQLConnection.tds_version
 
    The TDS version used by this connection. Can be one of ``4.2``, ``5.0``
-   ``7.0``, ``8.0`` and ``9.0``.
+   ``7.0``, ``8.0`` and ``7.2``.
 
 ``MSSQLConnection`` object methods
 ----------------------------------


### PR DESCRIPTION
Use the same numbering strategy as MS: There isn't TDS version 8.0 nor
9.0 but 7.1 and 7.2 respectively.

This is backward incompatible with user code that tests for value 8.0
when using TDS version 7.1.

Refs 32584060 and a8f58fa1.
