### PR TITLE
Add PEP 249 type constructors.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,10 @@ Bug fixes
   as 8.0 and 9.0; later it changed them to 7.1 and 7.2 respectively) and will
   be corrected in a future release.
 
+- PEP 249 compliance
+
+  Added type constructors to increase compatibility with other libraries.
+
 Version 2.1.0 - 2014-02-25 - `Marc Abramowitz <http://marc-abramowitz.com/>`_
 =============================================================================
 

--- a/pymssql.pyx
+++ b/pymssql.pyx
@@ -20,6 +20,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA  02110-1301  USA
 
+import datetime
+import time
+
 import _mssql
 cimport _mssql
 from cpython cimport bool, PY_MAJOR_VERSION
@@ -84,6 +87,14 @@ BINARY = DBAPIType(_mssql.BINARY)
 NUMBER = DBAPIType(_mssql.NUMBER)
 DATETIME = DBAPIType(_mssql.DATETIME)
 DECIMAL = DBAPIType(_mssql.DECIMAL)
+
+Date = datetime.date
+Time = datetime.time
+Timestamp = datetime.datetime
+DateFromTicks = lambda ticks: Date(*time.localtime(ticks)[:3])
+TimeFromTicks = lambda ticks: Time(*time.localtime(ticks)[3:6])
+TimestampFromTicks = lambda ticks: Timestamp(*time.localtime(ticks)[:6])
+Binary = bytes
 
 cdef dict DBTYPES = {
     'bool': _mssql.SQLBITN,


### PR DESCRIPTION
Copied @aaugustin's PR: https://github.com/pymssql/pymssql/pull/251 to the canonical repo so that the Travis CI tests can run on it.
