### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.tox
+*.venv
+SQLAlchemy*
+build
+dist

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,10 @@ Features
 - Floating point values are now accepted as Stored Procedure arguments. Thanks
   Runzhou Li (Leo) for the report and Bill Adams for the implementation.
 
+- Add Dockerfile and a Docker image and instructions on how to use it (GH-258)
+  This could be a convenient way to use pymssql without having to build stuff.
+  See http://pymssql.readthedocs.org/en/latest/intro.html#docker
+
 Bug fixes
 ---------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# --------------------------------------------------------------------------
+# This is a Dockerfile to build an Ubuntu 14.04 Docker image with
+# pymssql and FreeTDS
+#
+# Use a command like:
+#     docker build -t pymssql/pymssql .
+# --------------------------------------------------------------------------
+
+FROM  orchardup/python:2.7
+MAINTAINER  Marc Abramowitz <marc@marc-abramowitz.com> (@msabramo)
+
+# Install apt packages
+RUN apt-get update && apt-get install -y \
+    freetds-bin \
+    freetds-common \
+    freetds-dev
+
+RUN pip install Cython
+RUN pip install ipython
+RUN pip install SQLAlchemy
+RUN pip install pandas
+RUN pip install Alembic
+
+# Add source directory to Docker image
+# Note that it's beneficial to put this as far down in the Dockerfile as
+# possible to maximize the chances of being able to use image caching
+ADD . /opt/src/pymssql/
+
+RUN pip install /opt/src/pymssql
+
+CMD ["ipython"]

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -33,6 +33,77 @@ E.g.:
       brew install freetds
 
 
+Experimental: Use pymssql via `Docker <https://www.docker.com/>`_
+-----------------------------------------------------------------
+
+Another possible way to get started quickly with pymssql is to use a `Docker
+<https://www.docker.com/>`_ image.
+
+See the Docker docs for installation instructions for a number of platforms;
+you can try this link: https://docs.docker.com/installation/#installation
+
+There is a pymssql docker image on the Docker Registry at:
+
+https://registry.hub.docker.com/u/pymssql/pymssql/
+
+It is a Docker image with:
+
+* Ubuntu 14.04 LTS (trusty)
+* Python 2.7.6
+* pymssql 2.1.2.dev
+* FreeTDS 0.91
+* SQLAlchemy 0.9.8
+* Alembic 0.7.4
+* Pandas 0.15.2
+* Numpy 1.9.1
+* IPython 2.3.1
+
+To try it, first download the image (this requires Internet access and could
+take a while):
+
+.. code-block:: bash
+
+    docker pull pymssql/pymssql
+
+Then run a Docker container using the image with:
+
+.. code-block:: bash
+
+    docker run -it --rm pymssql/pymssql
+
+By default, if no command is specified, an `IPython <http://ipython.org>`_
+shell is invoked. You can override the command if you wish -- e.g.:
+
+.. code-block:: bash
+
+    docker run -it --rm pymssql/pymssql bin/bash
+
+Here's how using the Docker container looks in practice:
+
+.. code-block:: bash
+
+    $ docker pull pymssql/pymssql
+    ...
+    $ docker run -it --rm pymssql/pymssql
+    Python 2.7.6 (default, Mar 22 2014, 22:59:56)
+    Type "copyright", "credits" or "license" for more information.
+
+    IPython 2.1.0 -- An enhanced Interactive Python.
+    ?         -> Introduction and overview of IPython's features.
+    %quickref -> Quick reference.
+    help      -> Python's own help system.
+    object?   -> Details about 'object', use 'object??' for extra details.
+
+    In [1]: import pymssql; pymssql.__version__
+    Out[1]: u'2.1.1'
+
+    In [2]: import sqlalchemy; sqlalchemy.__version__
+    Out[2]: '0.9.7'
+
+    In [3]: import pandas; pandas.__version__
+    Out[3]: '0.14.1'
+
+
 Architecture
 ============
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -33,8 +33,10 @@ E.g.:
       brew install freetds
 
 
-Experimental: Use pymssql via `Docker <https://www.docker.com/>`_
------------------------------------------------------------------
+Docker
+------
+
+(Experimental)
 
 Another possible way to get started quickly with pymssql is to use a `Docker
 <https://www.docker.com/>`_ image.


### PR DESCRIPTION
for building Ubuntu [Docker](https://www.docker.com/) images with pymssql and [FreeTDS](http://www.freetds.org/) pre-installed.

## Using this Docker image ##

### Download the image ###

    docker pull pymssql/pymssql

### Run the image ###

    docker run -it --rm pymssql/pymssql

By default, if no command is specified, an [IPython][1] shell is invoked. You can override the command if you wish -- e.g.:

    docker run -it --rm pymssql/pymssql bin/bash

## Example usage ##

    $ docker pull pymssql/pymssql
    ...
    $ docker run -it --rm pymssql/pymssql
    Python 2.7.6 (default, Mar 22 2014, 22:59:56)
    Type "copyright", "credits" or "license" for more information.
    
    IPython 2.1.0 -- An enhanced Interactive Python.
    ?         -> Introduction and overview of IPython's features.
    %quickref -> Quick reference.
    help      -> Python's own help system.
    object?   -> Details about 'object', use 'object??' for extra details.
    
    In [1]: import pymssql; pymssql.__version__
    Out[1]: u'2.1.1'
    
    In [2]: import sqlalchemy; sqlalchemy.__version__
    Out[2]: '0.9.7'

    In [3]: import pandas; pandas.__version__
    Out[3]: '0.14.1'

  [1]: http://ipython.org/

I've uploaded a Docker image using this branch to the Docker Registry at:

https://registry.hub.docker.com/u/pymssql/pymssql/

Cc: @ramiro, @rsyring, @damoxc, @sontek, @aconrad