### PR TITLE
.travis.yml: Get back to fetching Cython wheels from PyPI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
 - pip install Sphinx sphinx-rtd-theme
 - pip --version
-- time pip install --use-wheel --no-index --find-links=http://wheels.astropy.org/ --find-links=http://wheels2.astropy.org/ Cython
+- pip install --use-wheel Cython
 - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi"
 install:
 - python setup.py install


### PR DESCRIPTION
See if it helps with Travis CI failures like this one:

https://travis-ci.org/pymssql/pymssql/jobs/39028455

i.e.:

```
Downloading/unpacking Cython

http://wheels.astropy.org/ uses an insecure transport scheme (http). Consider using https if heels.astropy.org has it available

http://wheels2.astropy.org/ uses an insecure transport scheme (http). Consider using https if heels2.astropy.org has it available

Could not find any downloads that satisfy the requirement Cython

Cleaning up...

No distributions at all found for Cython

Storing debug log for failure in /home/travis/.pip/pip.log
```
