### PR TITLE
Add tox "docs" target

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,15 +7,6 @@
 pymssql
 =======
 
-.. image:: https://travis-ci.org/pymssql/pymssql.png?branch=master
-        :target: https://travis-ci.org/pymssql/pymssql
-
-.. image:: http://img.shields.io/pypi/dm/pymssql.svg
-        :target: https://pypi.python.org/pypi/pymssql/
-
-.. image:: http://img.shields.io/pypi/v/pymssql.svg
-        :target: https://pypi.python.org/pypi/pymssql/
-
 A simple database interface for `Python`_ that builds on top of `FreeTDS`_ to
 provide a Python DB-API (`PEP-249`_) interface to `Microsoft SQL Server`_.
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,11 @@ deps =
 deps =
     {[testenv]deps}
     gevent
+
+[testenv:docs]
+deps =
+    Sphinx
+    sphinx_rtd_theme
+changedir = docs
+commands =
+    {envbindir}/sphinx-build -W -b html -d {envtmpdir}/doctrees . ./_build/html


### PR DESCRIPTION
I removed badge images to prevent these errors when running `sphinx-build -W`:

    WARNING: nonlocal image URI found: https://travis-ci.org/pymssql/pymssql.png?branch=master

Here's how it works:

```
$ tox -e docs
...
docs runtests: commands[0] | /Users/marca/dev/git-repos/pymssql/.tox/docs/bin/sphinx-build -W -b html -d /Users/marca/dev/git-repos/pymssql/.tox/docs/tmp/doctrees . ./_build/html
Running Sphinx v1.3b2
...
build succeeded.
...
  docs: commands succeeded
  congratulations :)

$ ls -l docs/_build/html/index.html
-rw-r--r--+ 1 marca  staff    25K Jan 28 10:19 docs/_build/html/index.html
```