### PR TITLE
Remove interpretation of string beginning with '0x' as hex values

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -1712,9 +1712,6 @@ cdef _quote_simple_value(value, charset='utf8'):
         return b'0x' + binascii.hexlify(bytes(value))
 
     if isinstance(value, (str, bytes)):
-        if value[0:2] == b'0x':
-            return value
-
         # see if it can be decoded as ascii if there are no null bytes
         if b'\0' not in value:
             try:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -91,6 +91,12 @@ class TestTypes(unittest.TestCase):
         typeeq(u'foobar', colval)
         self.hasheq(u'foobar', colval)
 
+    def test_varchar_hex(self):
+        testval = '0xf00'
+        colval = self.insert_and_select('comment_vch', testval, 's')
+        typeeq(u'0xf00', colval)
+        self.hasheq(u'0xf00', colval)
+
     def test_varchar_unicode(self):
         testval = u'foobär'
         colval = self.insert_and_select('comment_vch', testval, 's')
@@ -102,13 +108,6 @@ class TestTypes(unittest.TestCase):
         colval = self.insert_and_select('comment_nvch', testval, 's')
         typeeq(testval, colval)
         eq_(testval, colval)
-
-    def test_binary_string(self):
-        bindata = '{z\n\x03\x07\x194;\x034lE4ISo'.encode('ascii')
-        testval = '0x'.encode('ascii') + binascii.hexlify(bindata)
-        colval = self.insert_and_select('data_binary', testval, 's')
-        typeeq(bindata, colval)
-        eq_(bindata, colval)
 
     def test_binary_bytearray(self):
         bindata = '{z\n\x03\x07\x194;\x034lE4ISo'.encode('ascii')


### PR DESCRIPTION
Remove assumption that strings beginning with '0x' are valid hexadecimal values and are meant to be interpreted as binary data. 

Issue: #286 