### PR TITLE
make pymssql compile in PyPy

### DIFF
--- a/_mssql.pxd
+++ b/_mssql.pxd
@@ -35,7 +35,7 @@ cdef class MSSQLConnection:
     cpdef cancel(self)
     cdef void clear_metadata(self)
     cdef object convert_db_value(self, BYTE *, int, int)
-    cdef int convert_python_value(self, object value, BYTE **, int*, int*) except -1
+    cdef int convert_python_value(self, object value, BYTE **, int*, int*) except 1
     cpdef execute_query(self, query, params=?)
     cpdef execute_non_query(self, query, params=?)
     cpdef execute_row(self, query, params=?)

--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -69,6 +69,9 @@ cdef extern from "pymssql_version.h":
 
 cdef extern from "cpp_helpers.h":
     cdef bint FREETDS_SUPPORTS_DBSETLDBNAME
+    
+cdef extern from "pypy_helpers.h":
+    pass
 
 # Vars to store messages from the server in
 cdef int _mssql_last_msg_no = 0
@@ -139,45 +142,42 @@ SQLUUID = 36
 #######################
 ## Exception classes ##
 #######################
-cdef extern from "pyerrors.h":
-    ctypedef class __builtin__.Exception [object PyBaseExceptionObject]:
-        pass
-
-cdef class MSSQLException(Exception):
+class MSSQLException(Exception):
     """
     Base exception class for the MSSQL driver.
     """
 
-cdef class MSSQLDriverException(MSSQLException):
+class MSSQLDriverException(MSSQLException):
     """
     Inherits from the base class and raised when an error is caused within
     the driver itself.
     """
 
-cdef class MSSQLDatabaseException(MSSQLException):
+class MSSQLDatabaseException(MSSQLException):
     """
     Raised when an error occurs within the database.
     """
+    
+    def __init__(self, *args):
+        super(MSSQLException, self).__init__(*args)
+        self.number = 0
+        self.severity = 0
+        self.state = 0
+        self.line = 0
+        self.text = ""
+        self.srvname = ""
+        self.procname = ""
 
-    cdef readonly int number
-    cdef readonly int severity
-    cdef readonly int state
-    cdef readonly int line
-    cdef readonly char *text
-    cdef readonly char *srvname
-    cdef readonly char *procname
-
-    property message:
-
-        def __get__(self):
-            if self.procname:
-                return 'SQL Server message %d, severity %d, state %d, ' \
-                    'procedure %s, line %d:\n%s' % (self.number,
-                    self.severity, self.state, self.procname,
-                    self.line, self.text)
-            else:
-                return 'SQL Server message %d, severity %d, state %d, ' \
-                    'line %d:\n%s' % (self.number, self.severity,
+    @property
+    def message(self):
+        if self.procname:
+            return 'SQL Server message %d, severity %d, state %d, ' \
+                'procedure %s, line %d:\n%s' % (self.number,
+                self.severity, self.state, self.procname,
+                self.line, self.text)
+        else:
+            return 'SQL Server message %d, severity %d, state %d, ' \
+                'line %d:\n%s' % (self.number, self.severity,
                     self.state, self.line, self.text)
 
 # Module attributes for configuring _mssql
@@ -1600,13 +1600,13 @@ cdef int maybe_raise_MSSQLDatabaseException(MSSQLConnection conn) except 1:
         error_msg = b"Unknown error"
 
     ex = MSSQLDatabaseException((get_last_msg_no(conn), error_msg))
-    (<MSSQLDatabaseException>ex).text = error_msg
-    (<MSSQLDatabaseException>ex).srvname = get_last_msg_srv(conn)
-    (<MSSQLDatabaseException>ex).procname = get_last_msg_proc(conn)
-    (<MSSQLDatabaseException>ex).number = get_last_msg_no(conn)
-    (<MSSQLDatabaseException>ex).severity = get_last_msg_severity(conn)
-    (<MSSQLDatabaseException>ex).state = get_last_msg_state(conn)
-    (<MSSQLDatabaseException>ex).line = get_last_msg_line(conn)
+    ex.text = error_msg
+    ex.srvname = get_last_msg_srv(conn)
+    ex.procname = get_last_msg_proc(conn)
+    ex.number = get_last_msg_no(conn)
+    ex.severity = get_last_msg_severity(conn)
+    ex.state = get_last_msg_state(conn)
+    ex.line = get_last_msg_line(conn)
     db_cancel(conn)
     clr_err(conn)
     raise ex

--- a/pypy_helpers.h
+++ b/pypy_helpers.h
@@ -1,0 +1,8 @@
+#include "Python.h"
+
+/*
+ PyByteArrayCheck is not present in PyPy 2.5.1
+*/
+#ifndef PyByteArray_Check
+#define PyByteArray_Check(self) (0)
+#endif


### PR DESCRIPTION
These changes allow pymssql to compile and work under PyPy 2.5.1. It will be slow in PyPy since it uses the C API but it is better than nothing and it is more featureful than other options I tried. To make it work I had to inherit from Exception normally and define PyByteArray_Check if it is not defined. Since PyPy doesn't seem to have bytearray it's a pretty safe bet that False is the right answer. Let me know if this affects the tests; I do not have a server I can use against the tests.

Cython also noticed this function declared with except -1 in the .pxd and except 1 in the pyx, so I changed one of them to match. I'm not sure whether -1 or +1 is the correct value.
```
cdef int convert_python_value(self, object value, BYTE **, int*, int*) except 1
```

Fixes issue #308.