### PR TITLE
Fix method signature declaration/definition mismatch error.

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -819,7 +819,7 @@ cdef class MSSQLConnection:
             return (<char *>data)[:length]
 
     cdef int convert_python_value(self, object value, BYTE **dbValue,
-            int *dbtype, int *length) except 1:
+            int *dbtype, int *length) except -1:
         log("_mssql.MSSQLConnection.convert_python_value()")
         cdef int *intValue
         cdef double *dblValue


### PR DESCRIPTION
Cython 0.22 is more strict about this. See
https://github.com/cython/cython/blob/master/CHANGES.rst#022-2015-02-11
and http://docs.cython.org/src/userguide/language_basics.html#error-return-values