### PR TITLE
Update setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -444,7 +444,7 @@ setup(
       "Operating System :: Unix",
     ],
     zip_safe = False,
-    setup_requires=['setuptools_git'],
+    setup_requires=['setuptools-git'],
     tests_require=['pytest', 'unittest2'],
     ext_modules = ext_modules(),
 


### PR DESCRIPTION
'setuptools_git' changed to 'setuptools-git' because this is what the package is named under pip.  When using ''setuptools_git', dependency resolution fails, so palms off to easy_install which fails behind proxy.
