### PR TITLE
Handle null bytes in unicode the same as bytes

### DIFF
--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -1737,7 +1737,10 @@ cdef _quote_simple_value(value, charset='utf8'):
         return _quote_simple_value(str(value))
 
     if isinstance(value, unicode):
-        return ("N'" + value.replace("'", "''") + "'").encode(charset)
+        encoded = value.encode(charset)
+        if b'\0' in encoded:
+            return b'0x' + binascii.hexlify(encoded)
+        return (b"N'" + encoded.replace(b"'", b"''") + b"'")
 
     if isinstance(value, bytearray):
         return b'0x' + binascii.hexlify(bytes(value))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -122,6 +122,24 @@ class TestTypes(unittest.TestCase):
         typeeq(bindata, colval)
         eq_(bindata, colval)
 
+    def test_nullbyte_varchar(self):
+        testval = 'foo\0bar'.encode('ascii')
+        colval = self.insert_and_select('comment_vch', testval, 's')
+        typeeq(u'foo\0bar', colval)
+        eq_(u'foo\0bar', colval)
+
+    def test_nullbyte_varchar_unicode(self):
+        testval = u'foo\0bar'
+        colval = self.insert_and_select('comment_vch', testval, 's')
+        typeeq(testval, colval)
+        eq_(testval, colval)
+
+    def test_nullbyte_binary_bytearray(self):
+        bindata = 'foo\0bar'.encode('ascii')
+        colval = self.insert_and_select('data_binary', bytearray(bindata), 's')
+        typeeq(bindata, colval)
+        eq_(bindata, colval)
+
     def test_image(self):
         buf = get_bytes_buffer()
         longstr = 'a'*4000


### PR DESCRIPTION
Hi,

In the case where I make a query that passes a unicode value containing a null byte (e.g. `u'hello\0world'`) to a placeholder, I get an error from pymssql claiming the sql is invalid due to mismatched quotes.

It looks like when the resulting sql is converted to char\* the null byte is still there and it terminates the string.

I tested querying through _mssql as well as pymssql and both exhibit the bug.

If I pass a bytestring containing the null byte, it works fine, because there is some code that checks for null bytes and encodes the string as hex if there are any.

My proposed fix is to do the same thing for unicode values, because they can still contain null bytes (at least on python 2.7).

I've added a few tests that should hopefully illustrate the problem.
