### PR TITLE
tests: test_config. Handle code 18456 during connection attempts.

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,7 @@ class TestConfig(object):
         except _mssql.MSSQLDatabaseException as e:
             # we get this when the name or IP can be obtained but the connection
             # can not be made
-            if e.args[0][0] != 20009:
+            if e.args[0][0] not in (18456, 20009):
                 raise
         with open(config_dump_path, 'rb') as fh:
             return fh.read()


### PR DESCRIPTION
This condition was happening sporadically on the CI Appveyor servers and
causing these tests to fail.

As these tests actually don't connect to any real SQL Server but
precisely try a connection to a bougus server we don't lose generality
by introducing this change.