### PR TITLE
Issue #332

### DIFF
--- a/_mssql.pxd
+++ b/_mssql.pxd
@@ -42,7 +42,7 @@ cdef class MSSQLConnection:
     cpdef execute_scalar(self, query, params=?)
     cdef fetch_next_row(self, int, int)
     cdef format_and_run_query(self, query_string, params=?)
-    cdef format_sql_command(self, format, params=?)
+    cpdef format_sql_command(self, format, params=?)
     cdef get_result(self)
     cdef get_row(self, int, int)
 

--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -1167,7 +1167,7 @@ cdef class MSSQLConnection:
         finally:
             log("_mssql.MSSQLConnection.format_and_run_query() END")
 
-    cdef format_sql_command(self, format, params=None):
+    cpdef format_sql_command(self, format, params=None):
         log("_mssql.MSSQLConnection.format_sql_command()")
         return _substitute_params(format, params, self.charset)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -362,7 +362,15 @@ class CursorBase(DBAPIBase):
         eq_(len(cur.fetchmany(2)), 0)
         eq_(len(cur.fetchmany(2)), 0)
 
-    def test_execute_many(self):
+    def test_executemany_insert(self):
+        cur = self.executemany(
+            "insert into test (name) values (%(name)s)",
+            [{'name': 'a'}, {'name': 'b'}])
+        self.conn.commit()
+        eq_(self.t1.count(), 7)
+        eq_(cur.rowcount, 2)
+
+    def test_executemany_delete(self):
         cur = self.executemany(
             "delete from test where id = %(id)s",
             [{'id': 1}, {'id': 2}])


### PR DESCRIPTION
Faster implementation of `Cursor.executemany()`.

Code copied from #333 so it can be tested by our CI setup.
