### PR TITLE
_mssql.pyx: Fix RE syntax for matching 's' & 'd' in '%s', '%d'.

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -1788,8 +1788,8 @@ cdef _quote_data(data, charset='utf8'):
 
     raise ValueError('expected a simple type, a tuple or a dictionary.')
 
-_re_pos_param = re.compile(r'(%(s|d))')
-_re_name_param = re.compile(r'(%\(([^\)]+)\)(?:s|d))')
+_re_pos_param = re.compile(r'(%([sd]))')
+_re_name_param = re.compile(r'(%\(([^\)]+)\)(?:[sd]))')
 cdef _substitute_params(toformat, params, charset):
     if params is None:
         return toformat


### PR DESCRIPTION
Refs #291 and 4ec39bd2.