### PR TITLE
Use encoded string to match substitutions

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -1788,8 +1788,8 @@ cdef _quote_data(data, charset='utf8'):
 
     raise ValueError('expected a simple type, a tuple or a dictionary.')
 
-_re_pos_param = re.compile(r'(%([sd]))')
-_re_name_param = re.compile(r'(%\(([^\)]+)\)(?:[sd]))')
+_re_pos_param = re.compile(br'(%([sd]))')
+_re_name_param = re.compile(br'(%\(([^\)]+)\)(?:[sd]))')
 cdef _substitute_params(toformat, params, charset):
     if params is None:
         return toformat
@@ -1814,8 +1814,8 @@ cdef _substitute_params(toformat, params, charset):
     if isinstance(params, dict):
         """ assume name based substitutions """
         offset = 0
-        for match in _re_name_param.finditer(toformat.decode(charset)):
-            param_key = match.group(2)
+        for match in _re_name_param.finditer(toformat):
+            param_key = match.group(2).decode(charset)
 
             if not param_key in params:
                 raise ValueError('params dictionary did not contain value for placeholder: %s' % param_key)
@@ -1842,7 +1842,7 @@ cdef _substitute_params(toformat, params, charset):
     else:
         """ assume position based substitutions """
         offset = 0
-        for count, match in enumerate(_re_pos_param.finditer(toformat.decode(charset))):
+        for count, match in enumerate(_re_pos_param.finditer(toformat)):
             # calculate string positions so we can keep track of the offset to
             # be used in future substitutions on this string. This is
             # necessary b/c the match start() and end() are based on the

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,17 @@ def test_param_quote():
     eq_(res, b"SELECT * FROM empl WHERE name = N'John''s Doe'")
 
 
+def test_unicode_params():
+    res = substitute_params(
+        u'SELECT * FROM \u0394 WHERE name = %s',
+        u'\u03A8'
+    )
+    eq_(res, b"SELECT * FROM \xce\x94 WHERE name = N'\xce\xa8'")
+
+    res = substitute_params(u"testing ascii (\u0105\u010D\u0119) 1=%d 'one'=%s", (1, u'str'))
+    eq_(res, b"testing ascii (\xc4\x85\xc4\x8d\xc4\x99) 1=1 'one'=N'str'")
+
+
 def test_single_param_with_d():
     res = substitute_params(
         'SELECT * FROM employees WHERE id = %d',


### PR DESCRIPTION
Fixes #185

Conflicts:
	_mssql.pyx

Code copied from #361 so it can be tested by our CI setup.