### PR TITLE
Remove another unconditional test skip added in 2e8efab0.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -453,3 +453,24 @@ class StoredProc(object):
 
     def __exit__(self, type, value, tb):
         self.drop()
+
+
+def get_sql_server_version(mssql_connection):
+    """
+    Returns the version of the SQL Server in use:
+    """
+    result = mssql_connection.execute_scalar(
+        "SELECT CAST(SERVERPROPERTY('ProductVersion') as varchar)"
+    )
+    ver_code = int(result.split('.')[0])
+    if ver_code >= 12:
+        major_version = 2014
+    if ver_code == 11:
+        major_version = 2012
+    elif ver_code == 10:
+        major_version = 2008
+    elif ver_code == 9:
+        major_version = 2005
+    else:
+        major_version = 2000
+    return major_version

--- a/tests/test_sprocs.py
+++ b/tests/test_sprocs.py
@@ -8,7 +8,7 @@ import _mssql
 
 import pytest
 
-from .helpers import mssqlconn, pymssqlconn, eq_, skip_test
+from .helpers import mssqlconn, pymssqlconn, eq_, skip_test, get_sql_server_version
 
 FIXED_TYPES = (
     'BigInt',
@@ -202,8 +202,9 @@ class TestFixedTypeConversion(unittest.TestCase):
         proc.execute()
         eq_(input, proc.parameters['@otinyint'])
 
-    @pytest.mark.xfail
     def testUuid(self):
+        if get_sql_server_version(self.mssql) <= 2008:
+            pytest.skip("UNIQUEIDENTIFIER as a SP param doesn't work with SQL Server 2008")
         import uuid
         input = uuid.uuid4()
         proc = self.mssql.init_procedure('pymssqlTestUniqueIdentifier')


### PR DESCRIPTION
The test case only fails when running against SQL Server 2008.

Add a helper function which reports SQL Server version and can aid in
setting up this kind of conditional test cases skipping.