### PR TITLE
Report TDS version 7.1 as 7.1 instead of 8.0.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,20 @@
 Change Log
 ==========
 
+Version 2.2.0 - To be released
+==============================
+
+Features
+--------
+
+TBA
+
+Bug fixes
+---------
+
+- Fix ``tds_version``  ``_mssql`` connection property value for TDS version.
+  7.1 is actually 7.1 and not 8.0.
+
 Version 2.1.2 - 2016-02-10 - Ramiro Morales
 ===============================================
 

--- a/ChangeLog_highlights.rst
+++ b/ChangeLog_highlights.rst
@@ -1,6 +1,20 @@
 Recent Changes
 ==============
 
+Version 2.2.0 - To be released
+==============================
+
+Features
+--------
+
+TBA
+
+Bug fixes
+---------
+
+- Fix ``tds_version``  ``_mssql`` connection property value for TDS version.
+  7.1 is actually 7.1 and not 8.0.
+
 Version 2.1.2 - 2016-02-10 - Ramiro Morales
 ===============================================
 

--- a/docs/ref/_mssql.rst
+++ b/docs/ref/_mssql.rst
@@ -175,11 +175,6 @@ Functions
        For correctness and consistency the value used to indicate TDS 7.1
        changed from ``8.0`` to ``7.1`` on pymssql 2.2.0.
 
-   .. warning::
-      For historical and backward compatibility reasons, the value used to
-      represent TDS 7.1 is ``8.0``. This will change with pymssql 2.2.0 when it
-      will be fixed to be ``7.1`` for correctness and consistency.
-
 ``MSSQLConnection`` object methods
 ----------------------------------
 

--- a/docs/ref/_mssql.rst
+++ b/docs/ref/_mssql.rst
@@ -169,7 +169,11 @@ Functions
 .. attribute:: MSSQLConnection.tds_version
 
    The TDS version used by this connection. Can be one of ``4.2``, ``5.0``
-   ``7.0``, ``8.0`` and ``7.2``.
+   ``7.0``, ``7.1`` and ``7.2``.
+
+   .. versionchanged:: 2.2.0
+       For correctness and consistency the value used to indicate TDS 7.1
+       changed from ``8.0`` to ``7.1`` on pymssql 2.2.0.
 
    .. warning::
       For historical and backward compatibility reasons, the value used to

--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -515,7 +515,7 @@ cdef class MSSQLConnection:
             if version == 10:
                 return 7.2
             elif version == 9:
-                return 8.0  # Actually 7.1, return 8.0 to keep backward compatibility
+                return 7.1
             elif version == 8:
                 return 7.0
             elif version == 6:


### PR DESCRIPTION
This is a backward-incompatible change.