### PR TITLE
update expected types for binary sproc args for py2 & py3 compatibility

### DIFF
--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -971,8 +971,10 @@ cdef class MSSQLConnection:
             return 0
 
         if dbtype[0] in (SQLBINARY, SQLVARBINARY, SQLIMAGE):
-            if type(value) is not str:
-                raise TypeError('value can only be str')
+            if PY_MAJOR_VERSION == 3 and type(value) not in (bytes, bytearray):
+                raise TypeError('value can only be bytes or bytearray')
+            elif PY_MAJOR_VERSION == 2 and type(value) not in (str, bytearray):
+                raise TypeError('value can only be str or bytearray')
 
             binValue = <BYTE *>PyMem_Malloc(len(value))
             memcpy(binValue, <char *>value, len(value))


### PR DESCRIPTION
issue #425 

With types `SQLBINARY`, `SQLVARBINARY`, and `SQLIMAGE` only accepting `str` for input, in python 3 it seems no valid input types existed. I have expanded the type check to accept `bytes`, `bytearray` and `str` depending on the major python version.