### PR TITLE
Drop usage of `DBVERSION_80` symbol.

### DIFF
--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -1708,12 +1708,10 @@ cdef int _tds_ver_str_to_constant(verstr) except -1:
         return DBVERSION_42
     if verstr == u'7.0':
         return DBVERSION_70
-    if verstr == u'7.1':
+    if verstr in (u'7.1', u'8.0'):
         return DBVERSION_71
     if verstr == u'7.2':
         return DBVERSION_72
-    if verstr == u'8.0':
-        return DBVERSION_80
     raise MSSQLException('unrecognized tds version: %s' % verstr)
 
 #######################

--- a/src/sqlfront.pxd
+++ b/src/sqlfront.pxd
@@ -106,7 +106,6 @@ cdef extern from "sqlfront.h":
     int DBVERSION_70
     int DBVERSION_71
     int DBVERSION_72
-    int DBVERSION_80
 
     ## Type Constants ##
     cdef enum:


### PR DESCRIPTION
It was deprecated and was finally removed in FreeTDS 1.0.

Fixes #432.