### PR TITLE
Add example: connect using Windows Authentication

### DIFF
--- a/docs/pymssql_examples.rst
+++ b/docs/pymssql_examples.rst
@@ -44,6 +44,24 @@ Basic features (strict DB-API compliance)
 
     conn.close()
 
+Connecting using Windows Authentication
+=======================================
+
+When connecting using Windows Authentication, this is how to combine the
+database's hostname and instance name, and the Active Directory/Windows Domain
+name and the username. This example uses
+`raw strings <https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals>`_
+(``r'...'``) for the strings that contain a backslash.
+
+::
+
+    conn = pymssql.connect(
+        host=r'dbhostname\myinstance',
+        user=r'companydomain\username',
+        password=PASSWORD,
+        database='DatabaseOfInterest'
+    )
+
 Iterating through results
 =========================
 


### PR DESCRIPTION
I spent a good while figuring out how to specify the database server
host+instance, and where to specify the Windows Domain and the user.
Solution found here, and confirmed to work with pymssql 2.1.3:
https://groups.google.com/d/msg/pymssql/QDMLTGBNeU0/cncYUrkAJD4J