### PR TITLE
Address "'DBVERSION_80' undeclared" error during build

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -31,11 +31,10 @@ DEF MSSQLDB_MSGSIZE = 1024
 DEF PYMSSQL_MSGSIZE = (MSSQLDB_MSGSIZE * 8)
 DEF EXCOMM = 9
 
-# Provide constants missing in FreeTDS 0.82 so that we can build against it
 DEF DBVERSION_71 = 5
 DEF DBVERSION_72 = 6
-# Provide constant missing from FreeTDS 0.91 so that we can build against it
 DEF DBVERSION_73 = 7
+DEF DBVERSION_80 = DBVERSION_71
 
 ROW_FORMAT_TUPLE = 1
 ROW_FORMAT_DICT = 2

--- a/setup.py
+++ b/setup.py
@@ -463,6 +463,7 @@ setup(
       "Programming Language :: Python :: 3.3",
       "Programming Language :: Python :: 3.4",
       "Programming Language :: Python :: 3.5",
+      "Programming Language :: Python :: 3.6",
       "Programming Language :: Python :: Implementation :: CPython",
       "Topic :: Database",
       "Topic :: Database :: Database Engines/Servers",


### PR DESCRIPTION
Creating a pull-request for the branch/tag mentioned as the solution to multiple issues w/ ``v2.1.3``
---

We have been using this patch in _production_ for about 3 months w/o issue and despite this appearing to be fixed in ``2.2.0``, we wanted contribute upstream for anyone unwilling to use the _development_ branch/build.

Changes include:
---

* Alias ``DBVERSION_80`` to ``DBVERSION_71`` for consistency with the pattern
  applied elsewhere in this project
* Add Python 3.6 classifier into setup.py
* Add documentation of the fix to ChangeLog & ChangeLog_highlights.rst
  for target release
* Set version to ``2.1.3.0.0.1`` in accordance w/ our (Wayfair's) 3rd party library [fork] versioning scheme (I'm happy to drop/update this and the above prior to when this PR is merged)