### PR TITLE
Fixed UnicodeEncodeError when connecting to database with non-ascii name

### DIFF
--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -647,7 +647,7 @@ cdef class MSSQLConnection:
         # Put the DB name in the login LOGINREC because it helps with connections to Azure
         if database:
             if FREETDS_SUPPORTS_DBSETLDBNAME:
-                dbname_bytes = database.encode('ascii')
+                dbname_bytes = database.encode()
                 dbname_cstr = dbname_bytes
                 DBSETLDBNAME(login, dbname_cstr)
             else:


### PR DESCRIPTION
I think that this should fix the error in #484.