### PR TITLE
Removing Python 3.3 from build definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - 2.7
-- 3.3
 - 3.4
 - 3.5
 - 3.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,14 +36,6 @@ environment:
       TDS_VER: "7.0"
       INSTANCENAME: "SQL2008R2SP2"
 
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.7"
-      PYTHON_ARCH: "32"
-      ARCH: x86
-      VS_VER: "2010"
-      TDS_VER: "7.1"
-      INSTANCENAME: "SQL2008R2SP2"
-
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.7"
       PYTHON_ARCH: "32"
@@ -70,14 +62,6 @@ environment:
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.14"
-      PYTHON_ARCH: "64"
-      ARCH: x86_64
-      VS_VER: "2010"
-      TDS_VER: "7.2"
-      INSTANCENAME: "SQL2008R2SP2"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.7"
       PYTHON_ARCH: "64"
       ARCH: x86_64
       VS_VER: "2010"
@@ -116,14 +100,6 @@ environment:
       TDS_VER: "7.0"
       INSTANCENAME: "SQL2012SP1"
 
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.7"
-      PYTHON_ARCH: "32"
-      ARCH: x86
-      VS_VER: "2010"
-      TDS_VER: "7.1"
-      INSTANCENAME: "SQL2012SP1"
-
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.7"
       PYTHON_ARCH: "32"
@@ -150,14 +126,6 @@ environment:
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.14"
-      PYTHON_ARCH: "64"
-      ARCH: x86_64
-      VS_VER: "2010"
-      TDS_VER: "7.2"
-      INSTANCENAME: "SQL2012SP1"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.7"
       PYTHON_ARCH: "64"
       ARCH: x86_64
       VS_VER: "2010"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35
+envlist = py27, py34, py35, py36
 
 [testenv]
 changedir = {toxworkdir}


### PR DESCRIPTION
Removing Python 3.3 support due to SQLAlchemy dependency and version support.

ref #563 #557