### PR TITLE
Remove duplicate condition for DBVERSION_71

### DIFF
--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -1751,8 +1751,6 @@ cdef int _tds_ver_str_to_constant(verstr) except -1:
         return DBVERSION_72
     if verstr == u'7.3':
         return DBVERSION_73
-    if verstr == u'8.0':
-        return DBVERSION_71
     raise MSSQLException('unrecognized tds version: %s' % verstr)
 
 #######################


### PR DESCRIPTION
The removed check is covered earlier on line 1748:
if verstr in (u'7.1', u'8.0'):