### PR TITLE
Specify Cython build requirement in pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,9 @@ before_install:
 - travis_retry pip install pytest SQLAlchemy
 - travis_retry pip install Sphinx sphinx-rtd-theme
 - pip --version
-- travis_retry pip install Cython
 install:
 - if [[ $FREETDS_VERSION == '1.00' ]]; then dev/build_freetds_linux.sh; export PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1; fi
-- python setup.py develop
+- pip install --editable .
 script:
 - . dev/travis_env.sh
 - echo "\$PYMSSQL_TEST_DATABASE = \"$PYMSSQL_TEST_DATABASE\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -237,7 +237,7 @@ before_build:
   - mv freetds/vs%VS_VER%_%PYTHON_ARCH%-%FREETDS_BRANCH% freetds/vs%VS_VER%_%PYTHON_ARCH%
 
 build_script:
-  - "%CMD_IN_ENV% python setup.py install"
+  - "%CMD_IN_ENV% pip install ."
 
 before_test:
   - copy dev\appveyor\tests.cfg tests\
@@ -264,7 +264,7 @@ after_test:
       $file = '.\junit.xml'
       (New-Object 'System.Net.WebClient').UploadFile($url, (Resolve-Path $file))
   # If tests are successful, create binary packages for the project.
-  - "%CMD_IN_ENV% python setup.py bdist_wheel"
+  - "%CMD_IN_ENV% pip wheel ."
 
 artifacts:
   - path: dist\*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]


### PR DESCRIPTION
[PEP 518](https://www.python.org/dev/peps/pep-0518/) introduces a standard way for Python packages to specify their build system requirements in the `pyproject.toml` file. Pip [supports this since version 10.0](https://pip.pypa.io/en/stable/reference/pip/#pep-518-support). If `pyproject.toml` is present in the source tree, pip automatically installs build system requirements specified in this file before attempting to execute `setup.py`.

This PR adds a `pyproject.toml` file with the additional Cython requirement. This way the installation with pip should just work. Should fix #578 and other similar issues.