### PR TITLE
Import Iterable from collections.abc instead of collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tests/tests.cfg
 .tox
 dist
 *.egg
+*.eggs
 *.egg-info
 docs/_build
 SQLAlchemy-*/

--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -42,7 +42,7 @@ cdef int _ROW_FORMAT_DICT = ROW_FORMAT_DICT
 
 from cpython cimport PY_MAJOR_VERSION, PY_MINOR_VERSION
 
-from collections import Iterable
+from collections.abc import Iterable
 import os
 import sys
 import socket


### PR DESCRIPTION
This resolves the following `DeprecationWarning`:
```
In [1]: import pymssql                                                                                                                                          
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```