### PR TITLE
fixed bytes/unicode type conversion

### DIFF
--- a/src/pymssql.pyx
+++ b/src/pymssql.pyx
@@ -99,7 +99,8 @@ Binary = bytes
 
 cdef dict DBTYPES = {
     'bool': _mssql.SQLBITN,
-    'str': _mssql.SQLVARCHAR,
+    'str': _mssql.SQLVARBINARY,
+    'bytes': _mssql.SQLVARBINARY,
     'unicode': _mssql.SQLVARCHAR,
     'Decimal': _mssql.SQLDECIMAL,
     'datetime': _mssql.SQLDATETIME,


### PR DESCRIPTION
see: https://cython.readthedocs.io/en/latest/src/tutorial/strings.html#python-string-types-in-cython-code

Untested, because I cannot setup my environment for building right now. But it seems like the right thing to do...

However the tests here are failing due to inconsistent use of strings/bytes/unicode in the tests as well. I did not modify them.