### PR TITLE
Issue 631: handle dead connections on sql server failover with freetds 1.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,2 @@
 pytest
 SQLAlchemy
-unittest2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+SQLAlchemy
+unittest2

--- a/setup.py
+++ b/setup.py
@@ -438,6 +438,10 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
+def parse_test_requirements():
+    with open('requirements-test.txt') as r:
+        return r.readlines()
+
 setup(
     name  = 'pymssql',
     version = extract_version(),
@@ -478,7 +482,7 @@ setup(
     ],
     zip_safe = False,
     setup_requires=['setuptools_git'],
-    tests_require=['pytest', 'unittest2'],
+    tests_require=parse_test_requirements(),
     ext_modules = ext_modules(),
 
 )

--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -1979,21 +1979,29 @@ MssqlConnection = MSSQLConnection
 ## Test Helper Functions ##
 ###########################
 
-def test_err_handler(connection, int severity, int dberr, int oserr, dberrstr, oserrstr):
+def test_err_handler(connection, int severity, int dberr, int oserr, dberrstr, oserrstr,
+                     mark_connection_as_dead=False):
     """
     Expose err_handler function and its side effects to facilitate testing.
     """
     cdef DBPROCESS *dbproc = NULL
     cdef char *dberrstrc = NULL
     cdef char *oserrstrc = NULL
+
     if dberrstr:
         dberrstr_byte_string = dberrstr.encode('UTF-8')
         dberrstrc = dberrstr_byte_string
+
     if oserrstr:
         oserrstr_byte_string = oserrstr.encode('UTF-8')
         oserrstrc = oserrstr_byte_string
+
     if connection:
-        dbproc = (<MSSQLConnection>connection).dbproc
+        if mark_connection_as_dead:
+            (<MSSQLConnection>connection).dbproc = dbproc = NULL
+        else:
+            dbproc = (<MSSQLConnection>connection).dbproc
+
     results = (
         err_handler(dbproc, severity, dberr, oserr, dberrstrc, oserrstrc),
         get_last_msg_str(connection),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from .helpers import cfgpath, clear_db, get_app_lock, release_app_lock
 _parser = ConfigParser({
     'server': 'localhost',
     'username': 'sa',
-    'password': '',
+    'password': 'YourStrong!Passw0rd',
     'database': 'tempdb',
     'port': '1433',
     'ipaddress': '127.0.0.1',

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,11 +1,7 @@
 from __future__ import with_statement
 from os import path, makedirs, environ
 import re
-import shutil
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import _mssql
 

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -2,10 +2,7 @@
 Test context managers -- i.e.: the `with` statement
 """
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pymssql import InterfaceError
 from .helpers import pymssqlconn, mssqlconn

--- a/tests/test_err_handle.py
+++ b/tests/test_err_handle.py
@@ -1,7 +1,8 @@
-from datetime import datetime
 import unittest
 
 import _mssql
+
+from tests.helpers import mssqlconn
 
 
 class ErrHandleTests(unittest.TestCase):
@@ -78,6 +79,51 @@ class ErrHandleTests(unittest.TestCase):
             connection, severity, dberr, oserr, dberrstr, oserrstr)
         self.assertEqual(values[0], 2)
         self.assertEqual(values[1], expect)
+
+    def test_errors_above_min_severity_trigger_dead_conns_to_be_marked_as_disconnected(self):
+        connection = mssqlconn()
+        severity = 10
+        dberr = 103
+        oserr = 1003
+        dberrstr = "toblerone3"
+        oserrstr = "cabezon"
+
+        expect = (
+            "DB-Lib error message %d, severity %d:\n%s\n"
+            "Operating System error during %s (%d)\n" % (
+                dberr, severity, dberrstr, oserrstr, oserr))
+        expect = expect.encode('UTF-8')
+
+        values = _mssql.test_err_handler(
+            connection, severity, dberr, oserr, dberrstr, oserrstr,
+            mark_connection_as_dead=True)
+
+        self.assertEqual(values[0], 2)
+        self.assertEqual(values[1], expect)
+
+        assert connection.connected is False
+
+    def test_errors_below_min_severity_still_trigger_dead_conns_to_be_marked_as_disconnected(self):
+        # ensure dead connections are closed even if severity < min error severity
+        severity = 1
+        dberr = 20047
+        oserr = 0
+        dberrstr = "DBPROCESS is dead or not enabled"
+        oserrstr = "Success"
+
+        expect = b""
+
+        connection = mssqlconn()
+
+        values = _mssql.test_err_handler(
+            connection, severity, dberr, oserr, dberrstr, oserrstr,
+            mark_connection_as_dead=True)
+
+        self.assertEqual(values[0], 2)
+        self.assertEqual(values[1], expect)
+
+        assert connection.connected is False
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_user_msghandler.py
+++ b/tests/test_user_msghandler.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from .helpers import config, mssqlconn
 


### PR DESCRIPTION
Issue: https://github.com/pymssql/pymssql/issues/631

Changes:
* moved the "short-circuit return if severity < min severity" check to after the DBDEAD connection check so that the DBDEAD check is applied regardless of error severity (FreeTDS returns a severity level 1 for dead connections after a failover). The DBDEAD check itself is extremely lightweight (a few boolean checks [here](https://github.com/FreeTDS/freetds/blob/master/src/dblib/dblib.c#L5038) and [here](https://github.com/FreeTDS/freetds/blob/master/include/freetds/tds.h#L1618)) so it should have a negligible performance impact
* extended test_err_handler in _mssql.pyx with optional param for marking a connection as dead via setting dbproc to NULL, which causes the DBDEAD freetds func to return True for testing
* added tests to ensure that the dbdead check is applied for connections regardless of whether the severity is less than the min severity level.
* updated the default password config in conftest.py to match the password supplied to the sqlserver container in the docker-compose.yml file so that some tests can be ran locally as long as the mssql-server-linux container is running
* broke out test requirements into a separate requirements-test.txt file for maintainability and so its obvious what python libs are required for testing (todo: use this in other pip install cmds)
* removed unittest2 dependency and usage since python 2.7 is the oldest supported python version