### PR TITLE
Python 3.8 Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,8 +156,6 @@ SYSTEM = platform.system()
 
 print("setup.py: platform.system() => %r" % SYSTEM)
 print("setup.py: platform.architecture() => %r" % (platform.architecture(),))
-if SYSTEM == 'Linux':
-    print("setup.py: platform.linux_distribution() => %r" % (platform.linux_distribution(),))
 if SYSTEM != 'Windows':
     print("setup.py: platform.libc_ver() => %r" % (platform.libc_ver(),))
 


### PR DESCRIPTION
- Removing printing of platform.linux_distribution()