### PR TITLE
Improve TIME/DATETIME2 precision and handle DATETIMEOFFSET

### DIFF
--- a/src/_mssql.pxd
+++ b/src/_mssql.pxd
@@ -29,6 +29,7 @@ cdef class MSSQLConnection:
     cdef char *last_msg_proc
     cdef tuple column_names
     cdef tuple column_types
+    cdef dict timezones
 
     cdef object msghandler
 

--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -1907,6 +1907,9 @@ cdef _quote_simple_value(value, charset='utf8', tds_version_tuple=()):
                 value.hour, value.minute, value.second,
                 value.microsecond / 1000)
 
+    if isinstance(value, datetime.time):
+        return value.strftime("CAST('%H:%M:%S.%f' AS TIME)")
+
     if isinstance(value, datetime.date):
         return "{d '%04d-%02d-%02d'} " % (
         value.year, value.month, value.day)
@@ -1964,7 +1967,8 @@ cdef _substitute_params(toformat, params, charset, tds_version_tuple):
 
     if not issubclass(type(params),
             (bool, int, long, float, unicode, str, bytes, bytearray, dict, tuple,
-             datetime.datetime, datetime.date, dict, decimal.Decimal, uuid.UUID)):
+             datetime.datetime, datetime.date, datetime.time,
+             decimal.Decimal, uuid.UUID)):
         raise ValueError("'params' arg (%r) can be only a tuple or a dictionary." % type(params))
 
     if charset:

--- a/src/_mssql.pyx
+++ b/src/_mssql.pyx
@@ -147,6 +147,7 @@ SQLUUID = 36
 SQLDATE = 40
 SQLTIME = 41
 SQLDATETIME2 = 42
+SQLDATETIMEOFFSET = 43
 
 #######################
 ## Exception classes ##
@@ -860,6 +861,12 @@ cdef class MSSQLConnection:
             dbanydatecrack(self.dbproc, &di2, dbtype, data);
             return datetime.datetime(di2.year, di2.month, di2.day, di2.hour,
                 di2.minute, di2.second, (di2.nanosecond + 500) // 1000)
+
+        elif dbtype == SQLDATETIMEOFFSET:
+            dbanydatecrack(self.dbproc, &di2, dbtype, data);
+            tz = MSSQLTimezone(datetime.timedelta(minutes=di2.tzone))
+            return datetime.datetime(di2.year, di2.month, di2.day, di2.hour,
+                di2.minute, di2.second, (di2.nanosecond + 500) // 1000, tz)
 
         elif dbtype == SQLDATE:
             dbconvert(self.dbproc, dbtype, data, -1, SQLDATETIME,

--- a/src/sqlfront.pxd
+++ b/src/sqlfront.pxd
@@ -73,6 +73,20 @@ cdef extern from "sqlfront.h":
         DBINT millisecond
         DBINT tzone
 
+    ctypedef struct        DBDATEREC2:
+        DBINT year
+        DBINT quarter
+        DBINT month
+        DBINT day
+        DBINT dayofyear
+        DBINT week
+        DBINT weekday
+        DBINT hour
+        DBINT minute
+        DBINT second
+        DBINT nanosecond
+        DBINT tzone
+
     ctypedef struct DBNUMERIC:
         BYTE precision
         BYTE scale
@@ -303,6 +317,20 @@ cdef extern from "sqlfront.h":
     #   Return values:
     #     SUCCEED always
     RETCODE dbdatecrack(DBPROCESS *, DBDATEREC *, DBDATETIME *)
+
+    # Break any kind of date or time value into useful pieces.
+    #
+    #   Parameters:
+    #     dbproc    contains all information needed by db-lib to manage
+    #               communications with the server.
+    #     di        output: structure to contain the exploded parts of
+    #               datetime.
+    #     type      input: type of date/time value returned by dbcoltype().
+    #     data      input: date/time value to be converted.
+    #
+    #   Return values:
+    #     SUCCEED always
+    RETCODE dbanydatecrack(DBPROCESS *, DBDATEREC2 *, int, void *)
 
     # Get size of current row's data in a regular result column.
     #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ _parser = ConfigParser({
     'port': '1433',
     'ipaddress': '127.0.0.1',
     'instance': '',
+    'tds_version': '',
 })
 
 def pytest_addoption(parser):
@@ -55,6 +56,7 @@ def pytest_configure(config):
     th.config.port = os.getenv('PYMSSQL_TEST_PORT') or _parser.get(section, 'port')
     th.config.ipaddress = os.getenv('PYMSSQL_TEST_IPADDRESS') or _parser.get(section, 'ipaddress')
     th.config.instance = os.getenv('PYMSSQL_TEST_INSTANCE') or _parser.get(section, 'instance')
+    th.config.tds_version = os.getenv('PYMSSQL_TEST_TDS_VERSION') or _parser.get(section, 'tds_version') or None
     th.config.orig_decimal_prec = decimal.getcontext().prec
     th.mark_slow = pytest.mark.slow
     th.skip_test = pytest.skip

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -483,7 +483,7 @@ def get_sql_server_version(mssql_connection):
     ver_code = int(result.split('.')[0])
     if ver_code >= 12:
         major_version = 2014
-    if ver_code == 11:
+    elif ver_code == 11:
         major_version = 2012
     elif ver_code == 10:
         major_version = 2008

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -35,6 +35,7 @@ def mssqlconn(conn_properties=None):
         password=config.password,
         database=config.database,
         port=config.port,
+        tds_version=config.tds_version,
         conn_properties=conn_properties
     )
 
@@ -46,6 +47,7 @@ def pymssqlconn(**kwargs):
         password=config.password,
         database=config.database,
         port=config.port,
+        tds_version=config.tds_version,
         **kwargs
     )
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ import time
 import pytest
 
 def eq_(a, b):
-    assert a == b
+    assert a == b, '%r != %r' % (a, b)
 
 def skip_test(reason='No reason given to skip_test'):
     pytest.skip(reason)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -196,7 +196,7 @@ class TestTypes(unittest.TestCase):
             pytest.skip("TIME field type isn't supported by SQL Server versions prior to 2008.")
         if self.conn.tds_version < 7.3:
             pytest.skip("TIME field type isn't supported by TDS protocol older than 7.3.")
-        testval = time(3, 4, 5, 3000)
+        testval = time(3, 4, 5, 4321)
         colval = self.insert_and_select('stamp_time', testval, 's')
         typeeq(testval, colval)
         eq_(testval, colval)
@@ -206,7 +206,7 @@ class TestTypes(unittest.TestCase):
             pytest.skip("DATETIME2 field type isn't supported by SQL Server versions prior to 2008.")
         if self.conn.tds_version < 7.3:
             pytest.skip("DATETIME2 field type isn't supported by TDS protocol older than 7.3.")
-        testval = datetime(2013, 1, 2, 3, 4, 5, 3000)
+        testval = datetime(2013, 1, 2, 3, 4, 5, 4321)
         colval = self.insert_and_select('stamp_datetime2', testval, 's')
         typeeq(testval, colval)
         eq_(testval, colval)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -192,11 +192,10 @@ class TestTypes(unittest.TestCase):
             pytest.skip("TIME field type isn't supported by SQL Server versions prior to 2008.")
         if self.conn.tds_version < 7.3:
             pytest.skip("TIME field type isn't supported by TDS protocol older than 7.3.")
-        testval = datetime(2013, 1, 2, 3, 4, 5, 3000)
+        testval = time(3, 4, 5, 3000)
         colval = self.insert_and_select('stamp_time', testval, 's')
-        testval_no_date = testval.time()
-        typeeq(testval_no_date, colval)
-        eq_(testval_no_date, colval)
+        typeeq(testval, colval)
+        eq_(testval, colval)
 
     def test_datetime2(self):
         if get_sql_server_version(self.conn) < 2008:

--- a/tests/tests.cfg.tpl
+++ b/tests/tests.cfg.tpl
@@ -12,6 +12,7 @@ password = YourStrong!Passw0rd
 database = tempdb
 port = 1433
 ipaddress = 10.5.0.5
+tds_version = 7.1
 # Instance isn't working with docker even though select @@servicename returns MSSQLSERVER
 # instance = MSSQLSERVER
 
@@ -24,3 +25,4 @@ password = somepass
 database = testdb
 port = 1435
 instance = testinst
+tds_version = 7.3


### PR DESCRIPTION
These changes make a number of improvements in the handling of date/time data types.

## DATETIME2

DATETIME2 values can have precision of up to 0.1 microsecond.  However, pymssql 2.1.4 converts these values into DATETIME (both upon insertion and upon retrieval), so precision is lost both ways.

To correctly deserialize DATETIME2 values when they are retrieved from the database, we use `dbanydatecrack` (available since FreeTDS 0.95.73), as opposed to the combination of `dbconvert` and `dbdatecrack`.

To correctly serialize datetime values when they are inserted into the database, we convert the value to an expression like `CAST('2000-01-01 12:34:56.789123' AS DATETIME2)`, as opposed to `{ts '2000-01-01 12:34:56.789'}`.  For backward compatibility, however, this is *only* done if the TDS version is 7.3 or later.

## TIME

TIME is like DATETIME2 but includes only the time of day.

To deserialize these values, we use `dbanydatecrack`.

To serialize datetime.time values, we use an expression like `CAST('12:34:56.789123' AS TIME)`.  (pymssql 2.1.4 doesn't support use of datetime.time as a query parameter.)

## DATETIMEOFFSET

DATETIMEOFFSET is like DATETIME2 but also includes the current offset, in minutes, between local time and UTC.  The closest semantic equivalent in Python is an "aware" datetime object.

To deserialize these values, we use `dbanydatecrack`.  Since Python 2.7 lacks the built-in `datetime.timezone` class, we provide an equivalent helper class `MSSQLTimezone`.

To serialize these values, we convert the value to an expression like `CAST('2000-01-01 12:34:56.789123 +01:00' AS DATETIMEOFFSET)`, as opposed to `{ts '2000-01-01 12:34:56.789'}`.  For backward compatibility, this is only done if the TDS version is 7.3 or later.

## Miscellaneous notes

I've also made several small fixes to the test suite, to enable these behaviors to be tested.

This fixes issues #608, #646, and #649.

This appears to fix issue #662, although I don't understand why.  Perhaps a bug in `dbconvert`?

Comments welcome!  I'm far from being an expert on SQL Server, FreeTDS, or SQL in general, so there may be better ways to accomplish these things, or subtleties that I've missed.

