### PR TITLE
Check for clock_gettime() only when linking statically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ if not WINDOWS:
 print("setup.py: include_dirs =>", include_dirs)
 print("setup.py: library_dirs =>", library_dirs)
 
-if not WINDOWS:
+if LINK_FREETDS_STATICALLY and not WINDOWS:
     # check for clock_gettime, link with librt for glibc<2.17
     from dev import ccompiler
     compiler = ccompiler.new_compiler()


### PR DESCRIPTION
The extension module does not use clock_gettime() directly, so I presume
it is only necessary when linking statically to FreeTDS.