### PR TITLE
Fix ignoring simple parameters with a `False` truth value

### DIFF
--- a/src/pymssql/_mssql.pyx
+++ b/src/pymssql/_mssql.pyx
@@ -1248,7 +1248,7 @@ cdef class MSSQLConnection:
             # Cancel any pending results
             self.cancel()
 
-            if params:
+            if params is not None:
                 query_string = self.format_sql_command(query_string, params)
 
             # For Python 3, we need to convert unicode to byte strings

--- a/src/pymssql/_pymssql.pyx
+++ b/src/pymssql/_pymssql.pyx
@@ -449,12 +449,12 @@ cdef class Cursor:
         self.conn = None
         self.description = None
 
-    def execute(self, operation, params=()):
+    def execute(self, operation, params=None):
         self.description = None
         self._rownumber = 0
 
         try:
-            if not params:
+            if params is None:
                 self._source._conn.execute_query(operation)
             else:
                 self._source._conn.execute_query(operation, params)


### PR DESCRIPTION
Currently, all simple value parameters which evaluate to `False` are ignored (e.g. 0, ""). This results in an exception, since the provided value is not inserted into the query.

Fixes #609 