### PR TITLE
Fix freetds troubleshooting link

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -231,4 +231,4 @@ If the above hasn't covered the problem you can send a message describing it to
 the pymssql mailing list. You can also consult FreeTDS troubleshooting `page for
 issues related to the TDS protocol`_.
 
-.. _page for issues related to the TDS protocol: http://www.freetds.org/userguide/troubleshooting.htm
+.. _page for issues related to the TDS protocol: https://www.freetds.org/userguide/troubleshooting.html


### PR DESCRIPTION
The link to http://www.freetds.org/userguide/troubleshooting.htm returns a Not Found page. This is to update the link to use HTTPS, and end with .html which links as expected.