### PR TITLE
Fix convert_db_value attempting to use datetime.date non-existent microseconds attr

### DIFF
--- a/src/pymssql/_mssql.pyx
+++ b/src/pymssql/_mssql.pyx
@@ -970,9 +970,11 @@ cdef class MSSQLConnection:
         if dbtype[0] in (SQLDATETIM4, SQLDATETIME):
             if type(value) not in (datetime.date, datetime.datetime):
                 raise TypeError('value can only be a date or datetime')
-
+            microseconds = 0
+            if type(value)==datetime.datetime:
+                microseconds=value.microsecond // 1000
             value = value.strftime('%Y-%m-%d %H:%M:%S.') + \
-                "%03d" % (value.microsecond // 1000)
+                "%03d" % (microseconds)
             value = value.encode(self.charset)
             dbtype[0] = SQLCHAR
 


### PR DESCRIPTION
This fixes a issue with convert_db_value encoding dates with SQLDATETIM4/SQLDATETIME.