### PR TITLE
Make convert python value work with datetime.date 

### DIFF
--- a/src/pymssql/_mssql.pyx
+++ b/src/pymssql/_mssql.pyx
@@ -970,9 +970,11 @@ cdef class MSSQLConnection:
         if dbtype[0] in (SQLDATETIM4, SQLDATETIME):
             if type(value) not in (datetime.date, datetime.datetime):
                 raise TypeError('value can only be a date or datetime')
-
+            microseconds=0
+            if type(value) in (datetime.datetime,):
+                microseconds=value.microsecond // 1000
             value = value.strftime('%Y-%m-%d %H:%M:%S.') + \
-                "%03d" % (value.microsecond // 1000)
+                "%03d" % (microseconds)
             value = value.encode(self.charset)
             dbtype[0] = SQLCHAR
 


### PR DESCRIPTION
This fixes a exception raised in convert_python_value attempting to access the non-existent microsecond attribute of datetime.date.