### PR TITLE
Make code compatible with cython 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=54.0", 
     "setuptools_scm[toml]>=5.0,<7.0", 
     "wheel>=0.36.2", 
-    "Cython>=0.29.22"
+    "Cython>=0.29.32"
     ]
 
 [tool.setuptools_scm]

--- a/src/pymssql/_mssql.pyx
+++ b/src/pymssql/_mssql.pyx
@@ -256,7 +256,7 @@ cdef void log(char * message, ...):
 ## Error Handler ##
 ###################
 cdef int err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr,
-        char *dberrstr, char *oserrstr) with gil:
+        char *dberrstr, char *oserrstr) noexcept with gil:
     cdef char *mssql_lastmsgstr
     cdef int *mssql_lastmsgno
     cdef int *mssql_lastmsgseverity
@@ -329,7 +329,7 @@ cdef int err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr,
 #####################
 cdef int msg_handler(DBPROCESS *dbproc, DBINT msgno, int msgstate,
         int severity, char *msgtext, char *srvname, char *procname,
-        LINE_T line) with gil:
+        LINE_T line) noexcept with gil:
 
     cdef int *mssql_lastmsgno
     cdef int *mssql_lastmsgseverity


### PR DESCRIPTION
Cython 3 requires noexcept keyword for functions not returning exception: https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept
