### PR TITLE
Fix issue #650. Add missing 'charset' parameter

### DIFF
--- a/src/pymssql/_mssql.pyx
+++ b/src/pymssql/_mssql.pyx
@@ -2085,7 +2085,7 @@ cdef _substitute_params(toformat, params, charset):
             # do the string substitution
             match_start = match.start(1) + offset
             match_end = match.end(1) + offset
-            toformat = toformat[:match_start] + ensure_bytes(param_val) + toformat[match_end:]
+            toformat = toformat[:match_start] + ensure_bytes(param_val, charset) + toformat[match_end:]
 
             # adjust the offset for the next usage
             offset += offset_adjust
@@ -2111,7 +2111,7 @@ cdef _substitute_params(toformat, params, charset):
             # do the string substitution
             match_start = match.start(1) + offset
             match_end = match.end(1) + offset
-            toformat = toformat[:match_start] + ensure_bytes(param_val) + toformat[match_end:]
+            toformat = toformat[:match_start] + ensure_bytes(param_val, charset) + toformat[match_end:]
             #print(param_val, param_val_len, offset_adjust, match_start, match_end)
             # adjust the offset for the next usage
             offset += offset_adjust

--- a/tests/test_charset.py
+++ b/tests/test_charset.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+Test charset usage in queries.
+"""
+
+import unittest
+
+import pytest
+
+from .helpers import pymssqlconn
+
+
+@pytest.mark.mssql_server_required
+class TestCharset(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = pymssqlconn(charset='WINDOWS-1251')
+
+    def test_charset(self):
+        cursor = self.conn.cursor()
+
+        try:
+            cursor.execute(
+                'select %s, %s',
+                ('Здравствуй', 'Мир')  # Russian strings
+            )
+        except UnicodeDecodeError as e:
+            self.fail("cursor.execute() raised %s unexpectedly: %s" % (e.__class__.__name__, e))
+
+        a, b = cursor.fetchone()
+
+        self.assertEqual(a, 'Здравствуй')
+        self.assertEqual(b, 'Мир')


### PR DESCRIPTION
Fix #650

When encoding other than 'UTF-8' is used, an error occurs when `cursor.execute()` is called:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte ... in position ...: invalid continuation byte
```
This PR adds the missing `charset` parameter in the `_substitute_params` method when calling `ensure_bytes`