### PR TITLE
add commit() for callproc on doc pymssql examples

### DIFF
--- a/docs/pymssql_examples.rst
+++ b/docs/pymssql_examples.rst
@@ -201,6 +201,8 @@ db-lib.
             END
             """)
             cursor.callproc('FindPerson', ('Jane Doe',))
+            # you must call commit() to persist your data if you don't set autocommit to True
+            conn.commit()
             for row in cursor:
                 print("ID=%d, Name=%s" % (row['id'], row['name']))
 


### PR DESCRIPTION
conn.commit() is required for callproc, otherwise it doesn't work.
I've added this to doc pymssql examples "Calling stored procedures"