### PR TITLE
Fix dead link registry docker doc

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -6,7 +6,7 @@ Docker
 
 There is a pymssql Docker image on the Docker Registry at:
 
-https://registry.hub.docker.com/u/pymssql/pymssql/
+https://registry.hub.docker.com/r/pymssql/pymssql/
 
 The image bundles:
 

--- a/docs/pymssql_examples.rst
+++ b/docs/pymssql_examples.rst
@@ -201,6 +201,8 @@ db-lib.
             END
             """)
             cursor.callproc('FindPerson', ('Jane Doe',))
+            # you must call commit() to persist your data if you don't set autocommit to True
+            conn.commit()
             for row in cursor:
                 print("ID=%d, Name=%s" % (row['id'], row['name']))
 


### PR DESCRIPTION
I fixed a dead link redirecting to the pymssql docker registry