### PR TITLE
[FIX]using latest good 0.29.35 cython compiler for buildilng; cython=…

### DIFF
--- a/dev/requirements-dev.txt
+++ b/dev/requirements-dev.txt
@@ -1,4 +1,4 @@
-cython>=0.29.22
+cython==0.29.35
 gevent
 psutil<5.9.5
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=54.0", 
     "setuptools_scm[toml]>=5.0,<7.0", 
     "wheel>=0.36.2", 
-    "Cython>=0.29.22"
+    "Cython==0.29.35"
     ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=54.0", 
     "setuptools_scm[toml]>=5.0,<7.0", 
     "wheel>=0.36.2", 
-    "Cython==~0.29"
+    "Cython~=0.29"
     ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=54.0", 
     "setuptools_scm[toml]>=5.0,<7.0", 
     "wheel>=0.36.2", 
-    "Cython==0.29.35"
+    "Cython==~0.29"
     ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=54.0", 
     "setuptools_scm[toml]>=5.0,<7.0", 
     "wheel>=0.36.2", 
-    "Cython~=0.29"
+    "Cython==0.29.35"
     ]
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [options]
 setup_requires =
-    cython>=0.29.22
+    cython==0.29.35
     setuptools>=54.0
     setuptools_scm[toml]>=5.0,<7.0
     wheel>=0.36.2

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if have_c_files:
 else:
     # Force `setup_requires` stuff like Cython to be installed before proceeding
     from setuptools.dist import Distribution
-    Distribution(dict(setup_requires='Cython>=0.29.21'))
+    Distribution(dict(setup_requires='Cython==0.29.35'))
     from Cython.Distutils import build_ext as _build_ext
 
 def check_env(env_name, default):


### PR DESCRIPTION
…=3.0.0 which was recently released does not compile.

message is 

```
     dberrhandle(err_handler)
                  ^
  ------------------------------------------------------------

  src/pymssql/_mssql.pyx:2203:16: Cannot assign type 'int (DBPROCESS *, int, int, int, char *, char *) except? -1' to 'EHANDLEFUNC'

```

I checked the pyx source code and no obvious errors.

During pip3 install the setuptools download the 3.0.0 cython compiler which makes this error. cython==0.29.35 just works fine.

As cython==3.0.0 is released few days ago many people are complaining.
