### PR TITLE
More specific versioning for build dependencies

### DIFF
--- a/dev/requirements-dev.txt
+++ b/dev/requirements-dev.txt
@@ -1,12 +1,12 @@
-cython>=0.29.22
+cython>=0.29.32,<4
 gevent
 psutil<5.9.5
 pytest
 pytest-subtests
 pytest-timeout
-setuptools>=54.0
-setuptools_scm[toml]>=5.0,<8.0
+setuptools>=54.0,<69
+setuptools_scm[toml]>=5.0,<7.0
 sphinx-rtd-theme
 sphinx
 sqlalchemy
-wheel>=0.36.2
+wheel>=0.36.2,<0.42

--- a/dev/requirements-dev.txt
+++ b/dev/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest
 pytest-subtests
 pytest-timeout
 setuptools>=54.0,<69
-setuptools_scm[toml]>=5.0,<7.0
+setuptools_scm[toml]>=5.0,<8.0
 sphinx-rtd-theme
 sphinx
 sqlalchemy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-setuptools_scm[toml]>=5.0,<7.0
+setuptools_scm[toml]>=5.0,<8.0
 sphinx
 sphinx_rtd_theme
 sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-setuptools_scm[toml]>=5.0,<8.0
+setuptools_scm[toml]>=5.0,<7.0
 sphinx
 sphinx_rtd_theme
 sphinx-copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=54.0,<69", 
-    "setuptools_scm[toml]>=5.0,<7.0", 
+    "setuptools_scm[toml]>=5.0,<8.0", 
     "wheel>=0.36.2,<0.42", 
     "Cython>=0.29.32,<4"
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
-    "setuptools>=54.0", 
+    "setuptools>=54.0,<69", 
     "setuptools_scm[toml]>=5.0,<7.0", 
-    "wheel>=0.36.2", 
-    "Cython>=0.29.32"
+    "wheel>=0.36.2,<0.42", 
+    "Cython>=0.29.32,<4"
     ]
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 setup_requires =
     cython>=0.29.32,<4
     setuptools>=54.0,<69
-    setuptools_scm[toml]>=5.0,<7.0
+    setuptools_scm[toml]>=5.0,<8.0
     wheel>=0.36.2,<0.42

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [options]
 setup_requires =
-    cython>=0.29.22
-    setuptools>=54.0
+    cython>=0.29.32,<4
+    setuptools>=54.0,<69
     setuptools_scm[toml]>=5.0,<7.0
-    wheel>=0.36.2
+    wheel>=0.36.2,<0.42

--- a/setup.py
+++ b/setup.py
@@ -333,7 +333,7 @@ setup(
       "Operating System :: Unix",
     ],
     zip_safe = False,
-    setup_requires=['setuptools_scm[toml]>=5.0,<7.0', 'Cython>=0.29.32,<4'],
+    setup_requires=['setuptools_scm[toml]>=5.0,<8.0', 'Cython>=0.29.32,<4'],
     tests_require=['psutil<5.9.5', 'pytest', 'pytest-timeout'],
     ext_modules = ext_modules(),
     packages = [ 'pymssql'],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if have_c_files:
 else:
     # Force `setup_requires` stuff like Cython to be installed before proceeding
     from setuptools.dist import Distribution
-    Distribution(dict(setup_requires='Cython>=0.29.21'))
+    Distribution(dict(setup_requires='Cython>=0.29.32,<4'))
     from Cython.Distutils import build_ext as _build_ext
 
 def check_env(env_name, default):
@@ -333,7 +333,7 @@ setup(
       "Operating System :: Unix",
     ],
     zip_safe = False,
-    setup_requires=['setuptools_scm[toml]>=5.0,<8.0', 'Cython>=0.29.22'],
+    setup_requires=['setuptools_scm[toml]>=5.0,<7.0', 'Cython>=0.29.32,<4'],
     tests_require=['psutil<5.9.5', 'pytest', 'pytest-timeout'],
     ext_modules = ext_modules(),
     packages = [ 'pymssql'],


### PR DESCRIPTION
Sets a safe upper-bound for build dependencies.

Also aligns inconsistent versioning with `pyproject.toml` as the source of truth and updates to `setuptools-scm` v7 where it [was missed by Dependabot](https://github.com/pymssql/pymssql/commit/8e074c39fe78a828329f5e32bd7c2b778492c7a0).

Resolves https://github.com/pymssql/pymssql/issues/831.