### PR TITLE
Drop support for Python 3.6 & 3.7

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-20.04]
 
     services:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-            python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+            python-version: ['3.8', '3.9', '3.10', '3.11']
             os: [macos-latest]
 
     steps:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-            python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+            python-version: ['3.8', '3.9', '3.10', '3.11']
             os: [windows-latest]
             python-architecture: [x86, x64]
 

--- a/docs/building_and_developing.rst
+++ b/docs/building_and_developing.rst
@@ -7,7 +7,7 @@ _________________
 
 To build ``pymssql`` you should have:
 
-* `Python <https://python.org>`_ >= 3.6 including development files.
+* `Python <https://python.org>`_ >= 3.8 including development files.
   Please research your OS usual software distribution channels,
   e.g, ``python-dev`` or ``python-devel`` packages on Linux.
 * `Cython <https://cython.org>`_ -

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -81,7 +81,7 @@ FreeTDS. See the `relevant FreeTDS documentation`_ for additional details.
 Supported related software
 ==========================
 
-:Python: Python 3.x: 3.6 or newer.
+:Python: Python 3.x: 3.8 or newer.
 :FreeTDS: 1.2.18 or newer.
 :Cython: 0.29 or newer.
 :Microsoft SQL Server: 2005 or newer.

--- a/setup.py
+++ b/setup.py
@@ -318,8 +318,6 @@ setup(
       "Intended Audience :: Developers",
       "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
       "Programming Language :: Python",
-      "Programming Language :: Python :: 3.6",
-      "Programming Language :: Python :: 3.7",
       "Programming Language :: Python :: 3.8",
       "Programming Language :: Python :: 3.9",
       "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Resolves https://github.com/pymssql/pymssql/issues/834. See issue for details on the rationale behind these changes.