### PR TITLE
Correct typos in `src/` and `tests/`

### DIFF
--- a/src/pymssql/_mssql.pyx
+++ b/src/pymssql/_mssql.pyx
@@ -1133,7 +1133,7 @@ cdef class MSSQLConnection:
             conn.execute_query('SELECT * FROM empl WHERE id IN %s',\
                 (tuple([3,5,7,11]),))
 
-        This method is intented to be used on queries that return results,
+        This method is intended to be used on queries that return results,
         i.e. SELECT. After calling this method AND reading all rows from,
         result rows_affected property contains number of rows returned by
         last command (this is how MS SQL returns it).

--- a/src/pymssql/_pymssql.pyx
+++ b/src/pymssql/_pymssql.pyx
@@ -401,7 +401,7 @@ cdef class Cursor:
 
     def __iter__(self):
         """
-        Return self to make cursors compatibile with Python iteration
+        Return self to make cursors compatible with Python iteration
         protocol.
         """
         return self
@@ -621,7 +621,7 @@ def connect(server='.', user=None, password=None, database='', timeout=0,
     :keyword conn_properties: SQL queries to send to the server upon connection
                               establishment. Can be a string or another kind
                               of iterable of strings
-    :keyword autocommit: Whether to use default autocommiting mode or not
+    :keyword autocommit: Whether to use default autocommitting mode or not
     :type autocommit: boolean
     :keyword tds_version: TDS protocol version to use.
     :type tds_version: string
@@ -666,7 +666,7 @@ def connect(server='.', user=None, password=None, database='', timeout=0,
 
 def get_max_connections():
     """
-    Get the maximum number of simulatenous connections pymssql will open
+    Get the maximum number of simultaneous connections pymssql will open
     to the server.
     """
     return _mssql.get_max_connections()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -333,7 +333,7 @@ class CursorBase(DBAPIBase):
             #   FROM (VALUES (1), (2), (3))
             #   AS foo(x)
             #
-            # SQL Server = 2005 (remove when we drop suport for it):
+            # SQL Server = 2005 (remove when we drop support for it):
             #
             #   SELECT MAX(x), MIN(x) AS [MIN(x)]
             #   FROM (SELECT 1
@@ -362,7 +362,7 @@ class CursorBase(DBAPIBase):
             #   FROM (VALUES (1, 2), (2, 3), (3, 4))
             #   AS foo(x, y)
             #
-            # SQL Server = 2005 (remove when we drop suport for it):
+            # SQL Server = 2005 (remove when we drop support for it):
             #
             #   SELECT MAX(x), MAX(y) AS [MAX(y)], MIN(y)
             #   FROM (SELECT (1, 2)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,7 +80,7 @@ class TestConfig(object):
     def test_tds_protocol_version_80(self):
         # follow-up: turns out 8.0 was erroneous.  MS named the new protocol
         # 7.1 instead of 8.0, so FreeTDS will accept 8.0 but shows as 7.1.
-        # got that from the FreeTDS mailling list.  New FreeTDS docs,built from
+        # got that from the FreeTDS mailing list.  New FreeTDS docs,built from
         # source, have a page that describes the protocol and that page lists
         # versions 7.0, 7.1, and 7.2 among others.
 


### PR DESCRIPTION
Corrects typos found in docstrings and comments.