### PR TITLE
Fix windows wheel builds

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install OpenSSL x86
       if: matrix.python-architecture == 'x86'
-      run: choco install openssl --forcex86
+      run: choco install openssl --forcex86 --version=1.1.1.2100
 
     - name: Install OpenSSL x64
       if: matrix.python-architecture == 'x64'

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ class build_ext(_build_ext):
                     if BITNESS == 32:
                         e.library_dirs.append("c:/Program Files (x86)/OpenSSL-Win32/lib")
                     else:
-                        e.library_dirs.append("c:/Program Files/OpenSSL-Win64/lib")
+                        e.library_dirs.append("c:/Program Files/OpenSSL/lib")
 
         else:
             if LINK_KRB5:


### PR DESCRIPTION
Making way for Windows wheels https://github.com/pymssql/pymssql/issues/839

Changes:
- Windows x86: Use older OpenSSL since the newest does not install on x86 systems (choco issue, already reported)
- Windows x64: Fixing path to OpenSSL library since it seems the installation location changed.