### PR TITLE
State in the docs that executemany() has no performance benefits over just execute() in a for loop

### DIFF
--- a/docs/ref/pymssql.rst
+++ b/docs/ref/pymssql.rst
@@ -356,6 +356,8 @@ Cursor object methods
    list). Execute a database operation repeatedly for each element in parameter
    sequence.
 
+   Note: in current pymssql implementation `executemany()` has [no performance](https://github.com/pymssql/pymssql/issues/332) gains over just a `for` loop with `Cursor.execute()`
+
 .. method:: Cursor.fetchone()
 
    Fetch the next row of a query result, returning a tuple, or a dictionary if


### PR DESCRIPTION
And add link to this issue: https://github.com/pymssql/pymssql/issues/332

Like commenters say, there is no real meaning in using `executemany()` besides making the code compliant with some standard from other libraries defining `executemany()`.

Without this note it's super not obvious to the reader that `executemany()` is just an alias for a for loop. I believe most people would assume that this function exists to provide some sort of performance benefit over `execute()` like sending all generated queries in one round-trip as a bulk. Which only produces butthurt when they suddenly realize that there is an N+1 performance hole in their application from relying on this library's API.