### PR TITLE
Restrict setuptools <72

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [options]
 setup_requires =
     cython>=3.0.7
-    setuptools>=54.0
+    setuptools>=54.0,<72.0
     setuptools_scm[toml]>=5.0,<7.0
     wheel>=0.36.2

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ import struct
 import sys
 
 from setuptools import setup, Extension
+from setuptools.command.test import test as TestCommand
 
 from distutils import log
 from distutils.cmd import Command

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ import struct
 import sys
 
 from setuptools import setup, Extension
-from setuptools.command.test import test as TestCommand
 
 from distutils import log
 from distutils.cmd import Command


### PR DESCRIPTION
For some just restricting required setup tools <72 will work.  https://github.com/pymssql/pymssql/commit/d1d9df55e8d9a2d974ee6c6c020b6cbe91ee5501

Only removing `setuptools.command.test` from `setup.cfg` worked for us. See [6b8d9de](https://github.com/pymssql/pymssql/commit/6b8d9de2aae8d421836975f349568441740f849a) commit.

