### PR TITLE
Enable Python 3.13 tests and add PyPI trove classifier

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-20.04]
 
     services:
@@ -55,6 +55,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: build & install
       run: |

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Archive wheels and sdist
       uses: actions/upload-artifact@v4
       with:
-        name: pymssql-${{ matrix.runs-on }}-${{ matrix.manylinux }}_${{ matrix.arch }}-${{ github.sha }}
+        name: pymssql-linux-${{ matrix.manylinux }}_${{ matrix.arch }}-${{ github.sha }}
         path: dist
         overwrite: true
 

--- a/.github/workflows/test_linux_aarch64.yml
+++ b/.github/workflows/test_linux_aarch64.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Archive wheels and sdist
       uses: actions/upload-artifact@v4
       with:
-        name: pymssql-${{ matrix.runs-on }}-${{ matrix.manylinux }}_${{ matrix.arch }}-${{ github.sha }}
+        name: pymssql-linux-aarch64-${{ matrix.manylinux }}_${{ matrix.arch }}-${{ github.sha }}
         path: dist
         overwrite: true
 

--- a/.github/workflows/test_linux_aarch64.yml
+++ b/.github/workflows/test_linux_aarch64.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-20.04]
 
     services:
@@ -51,6 +51,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: build & install
       run: |

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-            python-version: ['3.9', '3.10', '3.11', '3.12']
+            python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
             os: [macos-13]
 
     steps:
@@ -44,6 +44,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
             python-version: ${{ matrix.python-version }}
+            allow-prereleases: true
 
     - name: build wheel and sdist
       run: |

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Archive wheels and sdist
       uses: actions/upload-artifact@v4
       with:
-        name: pymssql-${{ matrix.runs-on }}-${{ matrix.python-version }}-${{ github.sha }}
+        name: pymssql-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.sha }}
         path: dist
         overwrite: true
 

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-            python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+            python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
             os: [windows-latest]
             python-architecture: [x86, x64]
 
@@ -47,6 +47,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
             python-version: ${{ matrix.python-version }}
+            allow-prereleases: true
             architecture: ${{ matrix.python-architecture}}
 
     - name: Install OpenSSL x86

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Archive wheels and sdist
       uses: actions/upload-artifact@v4
       with:
-        name: pymssql-${{ matrix.runs-on }}-${{ matrix.python-architecture }}-${{ github.sha }}
+        name: pymssql-${{ matrix.os }}-${{ matrix.python-architecture }}-${{ github.sha }}
         path: dist
         overwrite: true
 

--- a/dev/requirements-dev.txt
+++ b/dev/requirements-dev.txt
@@ -4,7 +4,7 @@ psutil<5.9.9
 pytest
 pytest-subtests
 pytest-timeout
-setuptools>=54.0
+setuptools>=54.0,<74.0
 setuptools_scm[toml]>=5.0,<9.0
 sphinx-rtd-theme
 sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [options]
 setup_requires =
     cython>=3.0.7
-    setuptools>=54.0
+    setuptools>=54.0,<74.0
     setuptools_scm[toml]>=5.0,<7.0
     wheel>=0.36.2

--- a/setup.py
+++ b/setup.py
@@ -330,6 +330,7 @@ setup(
       "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
       "Programming Language :: Python :: 3.12",
+      "Programming Language :: Python :: 3.13",
       "Programming Language :: Python :: Implementation :: CPython",
       "Topic :: Database",
       "Topic :: Database :: Database Engines/Servers",


### PR DESCRIPTION
~~Currently failing because greenlet doesn't build on 3.13 (https://github.com/python-greenlet/greenlet/pull/396).~~