### PR TITLE
fix: Constrain cython to <3.1 until code is compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools>=54.0",
     "setuptools_scm[toml]>=8.0",
     "wheel>=0.36.2",
-    "Cython>=3.0.10",
+    "Cython>=3.0.10,<3.1",
     "tomli",
     ]
 


### PR DESCRIPTION
## Why?

The 3.1.0 release of Cython includes this change: [Map Python "int" type to PyLong](https://github.com/cython/cython/pull/5830). The effect is that `long` is no longer recognized as a valid type, only `int` going forward.

This PR is a band-aid to allow local builds to still work if compiling from source, using build isolation. The long-term solution is to use `int` instead of `long` in the source code, but I do not have enough familiarity with the code to determine the impact of that. #938 attempts that, and should be considered the long-term solution.

> [!NOTE]
> I had to close the previous PR, #942, due to licensing issues, and re-raise from my personal repo.