### PR TITLE
Update FreeTDS to 1.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ write_to_template = 'const char* PYMSSQL_VERSION = "{version}";'
 local_scheme = "no-local-version"
 
 [tool.freetds]
-version_for_pypi_wheels = "1.4.27"
+version_for_pypi_wheels = "1.5.6"
 
 [project]
 name =  "pymssql"


### PR DESCRIPTION
One of our customers can not connect to their SQL Server 2022, using an encrypted connection. FreeTDS adds support for this in 1.5