### PR TITLE
Update README.rst to say pymssql is no longer supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 pymssql - DB-API interface to Microsoft SQL Server
 ==================================================
 
+pymssql is no longer supported
+==================================================
+As per https://github.com/pymssql/pymssql/issues/668 (dated Nov 2019).   One possible alternative might be https://github.com/microsoft/mssql-python/wiki
+
 .. image:: https://github.com/pymssql/pymssql/workflows/Wheels/badge.svg
         :target: https://github.com/pymssql/pymssql/actions?query=workflow%3A%22Wheels%22
 


### PR DESCRIPTION
This is a fix for issue 1006 (https://github.com/pymssql/pymssql/issues/1006) which says: The README.rst file doesn't say that pymssql is no longer supported

Here's where it says pymssql is no longer supported:  https://github.com/pymssql/pymssql/blob/master/README.rst