### PR TITLE
Build Python 3.15 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
-      - run: pip install cibuildwheel==3.3.0
+      - run: pip install cibuildwheel==4.2.0
       - id: set-matrix
         run: |
           MATRIX_INCLUDE=$(

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,6 +19,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build_sdist:

--- a/dev/build_manylinux_wheels.sh
+++ b/dev/build_manylinux_wheels.sh
@@ -59,7 +59,7 @@ git config --global --add safe.directory /pymssql
     --static-freetds
 
 # Install Python dependencies and compile wheels
-PYTHONS="cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314"
+PYTHONS="cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314 cp315-cp315"
 for i in $PYTHONS; do
     PYBIN="/opt/python/$i/bin"
     if  [ -d ${PYBIN} ] ; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,6 @@ before-test = "pip install -r dev/requirements-test.txt"
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 container-engine = { name = "docker", create-args = ["--network", "host"] }
-# Skip EOL Python versions (3.8 and older) and PyPy, allow free-threaded builds for 3.14+
-skip = "pp3?-*"
 
 [tool.cibuildwheel.linux]
 environment = { PYMSSQL_FREETDS = "./deps", LD_LIBRARY_PATH = "./deps/lib", CFLAGS = "-Wno-incompatible-pointer-types" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database",
     "Topic :: Database :: Database Engines/Servers",
@@ -65,7 +66,7 @@ test-requires = "pytest"
 test-command = "pytest {project}/tests"
 container-engine = { name = "docker", create-args = ["--network", "host"] }
 # Skip EOL Python versions (3.8 and older) and PyPy, allow free-threaded builds for 3.14+
-skip = "cp3?8-* cp3?7-* cp3?6-* cp3?5-* cp3?4-* cp310t-* cp311t-* cp312t-* cp313t-* pp3?-*"
+skip = "pp3?-*"
 
 [tool.cibuildwheel.linux]
 environment = { PYMSSQL_FREETDS = "./deps", LD_LIBRARY_PATH = "./deps/lib", CFLAGS = "-Wno-incompatible-pointer-types" }


### PR DESCRIPTION
CPython 3.15 wheels are automatically built starting with [cibuildwheel v4.2.0](https://github.com/pypa/cibuildwheel/releases/tag/v4.2.0) and maintainers are encouraged to start publishing them.

https://discuss.python.org/t/python-3-15-0-release-candidate-1-is-here/108395
